### PR TITLE
fix: Rental insertion not being sent as a transaction

### DIFF
--- a/src/controllers/routes.ts
+++ b/src/controllers/routes.ts
@@ -15,7 +15,7 @@ export async function setupRouter(
   router.get("/ping", pingHandler)
   router.post(
     "/rentals-listings",
-    authorizationMiddleware.wellKnownComponents({ optional: true }),
+    authorizationMiddleware.wellKnownComponents({ optional: false }),
     components.schemaValidator.withSchemaValidatorMiddleware(RentalCreationSchema),
     rentalsListingsCreationHandler
   )

--- a/src/ports/rentals/component.ts
+++ b/src/ports/rentals/component.ts
@@ -130,10 +130,11 @@ export function createRentalsComponent(
 
     logger.info(buildLogMessageForRental("Authorized"))
 
+    const client = await database.getPool().connect()
     // Inserting the new rental
     try {
-      await database.query(SQL`BEGIN`)
-      const createdMetadata = await database.query<DBMetadata>(
+      await client.query(SQL`BEGIN`)
+      const createdMetadata = await client.query<DBMetadata>(
         SQL`INSERT INTO metadata (id, category, search_text, created_at) VALUES (${nft.id}, ${nft.category}, ${
           nft.searchText
         }, ${new Date(
@@ -142,7 +143,7 @@ export function createRentalsComponent(
       )
       logger.debug(buildLogMessageForRental("Inserted metadata"))
 
-      const createdRental = await database.query<DBRental>(
+      const createdRental = await client.query<DBRental>(
         SQL`INSERT INTO rentals (metadata_id, network, chain_id, expiration, signature, nonces, token_id, contract_address, rental_contract_address, status) VALUES (${
           nft.id
         }, ${rental.network}, ${rental.chainId}, ${new Date(rental.expiration)}, ${rental.signature}, ${
@@ -151,7 +152,7 @@ export function createRentalsComponent(
       )
       logger.debug(buildLogMessageForRental("Inserted rental"))
 
-      const createdRentalListing = await database.query<DBRentalListing>(
+      const createdRentalListing = await client.query<DBRentalListing>(
         SQL`INSERT INTO rentals_listings (id, lessor) VALUES (${createdRental.rows[0].id}, ${lessorAddress}) RETURNING *`
       )
 
@@ -167,10 +168,10 @@ export function createRentalsComponent(
       })
       insertPeriodsQuery.append(SQL` RETURNING *`)
 
-      const createdPeriods = await database.query<DBPeriods>(insertPeriodsQuery)
+      const createdPeriods = await client.query<DBPeriods>(insertPeriodsQuery)
       logger.debug(buildLogMessageForRental("Inserted periods"))
 
-      await database.query(SQL`COMMIT`)
+      await client.query(SQL`COMMIT`)
 
       return {
         ...createdRental.rows[0],
@@ -181,13 +182,15 @@ export function createRentalsComponent(
       }
     } catch (error) {
       logger.info(buildLogMessageForRental("Rolled-back query"))
-      await database.query(SQL`ROLLBACK`)
+      await client.query(SQL`ROLLBACK`)
 
       if ((error as any).constraint === "rentals_token_id_contract_address_status_unique_index") {
         throw new RentalAlreadyExists(nft.contractAddress, nft.tokenId)
       }
 
       throw new Error("Error creating rental")
+    } finally {
+      await client.release()
     }
   }
 


### PR DESCRIPTION
This PR changes the way the new rental listing is inserted by using a client from the pool of clients to use the same client until the transaction is finished.
The query method that was being used took a new client on each execution, making it impossible to perform a transaction.
This PR also makes it non optional to be authenticated when publishing a rental.