### PR TITLE
Feat: Update rental and metadata jobs

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -12,3 +12,5 @@ HTTP_SERVER_HOST=0.0.0.0
 MARKETPLACE_SUBGRAPH_URL=https://api.thegraph.com/subgraphs/name/decentraland/marketplace
 PG_COMPONENT_PSQL_CONNECTION_STRING=
 RENTALS_SUBGRAPH_URL=https://api.thegraph.com/subgraphs/name/decentraland/rentals-ethereum-goerli
+CHAIN_NAME=Goerli
+MAX_CONCURRENT_RENTAL_UPDATES=5

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
       tsconfig: "test/tsconfig.json",
     },
   },
+  globalSetup: ["<rootDir>/test/setupTests.js"],
   moduleFileExtensions: ["ts", "js"],
   transform: {
     "^.+\\.(ts|tsx)$": "ts-jest",

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,7 @@ module.exports = {
       tsconfig: "test/tsconfig.json",
     },
   },
-  globalSetup: ["<rootDir>/test/setupTests.js"],
+  globalSetup: "<rootDir>/test/setupTests.js",
   moduleFileExtensions: ["ts", "js"],
   transform: {
     "^.+\\.(ts|tsx)$": "ts-jest",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "decentraland-crypto-middleware": "^1.0.4",
         "decentraland-transactions": "^1.38.0",
         "ethers": "^5.6.9",
-        "p-limit": "^4.0.0",
+        "p-limit": "^3.1.0",
         "sql-template-strings": "^2.2.2"
       },
       "devDependencies": {
@@ -6938,14 +6938,14 @@
       }
     },
     "node_modules/p-limit": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
-      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dependencies": {
-        "yocto-queue": "^1.0.0"
+        "yocto-queue": "^0.1.0"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -8968,11 +8968,11 @@
       }
     },
     "node_modules/yocto-queue": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
-      "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "engines": {
-        "node": ">=12.20"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -14157,11 +14157,11 @@
       "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow=="
     },
     "p-limit": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
-      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "requires": {
-        "yocto-queue": "^1.0.0"
+        "yocto-queue": "^0.1.0"
       }
     },
     "p-locate": {
@@ -15700,9 +15700,9 @@
       "dev": true
     },
     "yocto-queue": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
-      "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g=="
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "decentraland-crypto-middleware": "^1.0.4",
         "decentraland-transactions": "^1.38.0",
         "ethers": "^5.6.9",
+        "p-limit": "^4.0.0",
         "sql-template-strings": "^2.2.2"
       },
       "devDependencies": {
@@ -6937,15 +6938,14 @@
       }
     },
     "node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
       "dependencies": {
-        "p-try": "^2.0.0"
+        "yocto-queue": "^1.0.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6961,6 +6961,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-timeout": {
@@ -8950,6 +8965,17 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+      "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   },
@@ -14131,12 +14157,11 @@
       "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow=="
     },
     "p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
       "requires": {
-        "p-try": "^2.0.0"
+        "yocto-queue": "^1.0.0"
       }
     },
     "p-locate": {
@@ -14146,6 +14171,17 @@
       "dev": true,
       "requires": {
         "p-limit": "^2.2.0"
+      },
+      "dependencies": {
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        }
       }
     },
     "p-timeout": {
@@ -15662,6 +15698,11 @@
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true
+    },
+    "yocto-queue": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+      "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "build": "tsc -p tsconfig.json",
     "start": "node --trace-warnings --abort-on-uncaught-exception --unhandled-rejections=strict dist/index.js",
     "start-dev": "ts-node src/index.ts",
-    "migrate": "node-pg-migrate --database-url-var PG_COMPONENT_PSQL_CONNECTION_STRING --envPath .env -j ts --tsconfig tsconfig.json -m ./migrations",
+    "migrate": "node-pg-migrate --database-url-var PG_COMPONENT_PSQL_CONNECTION_STRING --envPath .env -j ts --tsconfig tsconfig.json -m ./src/migrations",
     "test": "jest --forceExit --detectOpenHandles --coverage --verbose"
   },
   "devDependencies": {
@@ -31,7 +31,7 @@
     "decentraland-crypto-middleware": "^1.0.4",
     "decentraland-transactions": "^1.38.0",
     "ethers": "^5.6.9",
-    "p-limit": "^4.0.0",
+    "p-limit": "^3.1.0",
     "sql-template-strings": "^2.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "decentraland-crypto-middleware": "^1.0.4",
     "decentraland-transactions": "^1.38.0",
     "ethers": "^5.6.9",
+    "p-limit": "^4.0.0",
     "sql-template-strings": "^2.2.2"
   }
 }

--- a/src/components.ts
+++ b/src/components.ts
@@ -39,7 +39,7 @@ export async function initComponents(): Promise<AppComponents> {
   )
 
   const schemaValidator = await createSchemaValidatorComponent()
-  const rentals = await createRentalsComponent({ database, logs, marketplaceSubgraph, rentalsSubgraph })
+  const rentals = await createRentalsComponent({ database, logs, marketplaceSubgraph, rentalsSubgraph, config })
   const job = await createJobComponent({ logs }, () => undefined, 60 * 1000, { startupDelay: 4000 })
 
   return {

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,5 +1,6 @@
 import { IMetricsComponent } from "@well-known-components/interfaces"
 import { validateMetricsDeclaration } from "@well-known-components/metrics"
+import { metricDeclarations as graphMetrics } from "@well-known-components/thegraph-component"
 
 export const metricDeclarations = {
   test_ping_counter: {
@@ -7,6 +8,7 @@ export const metricDeclarations = {
     type: IMetricsComponent.CounterType,
     labelNames: ["pathname"],
   },
+  ...graphMetrics,
 }
 
 // type assertions

--- a/src/migrations/1654545715004_rentals.ts
+++ b/src/migrations/1654545715004_rentals.ts
@@ -8,6 +8,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
   pgm.createExtension("uuid-ossp", { ifNotExists: true })
 
   pgm.createType("status", ["open", "executed", "cancelled"])
+  pgm.createType("update", ["metadata", "rentals"])
 
   pgm.createTable("metadata", {
     id: { type: "string", notNull: true, primaryKey: true },
@@ -58,7 +59,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
   })
 
   pgm.createTable("updates", {
-    id: { type: "uuid", primaryKey: true, default: pgm.func("uuid_generate_v4()") },
+    type: { type: "update", primaryKey: true, notNull: true },
     updated_at: { type: "timestamp", notNull: true, default: pgm.func("to_timestamp(0)") },
   })
 
@@ -71,6 +72,8 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
   // Ensure that there won't be more than one open rental per token
   pgm.createIndex("rentals", ["token_id", "contract_address", "status"], { where: "status = 'open'", unique: true })
   pgm.createIndex("updates", "updated_at")
+
+  pgm.sql("INSERT INTO updates (type, updated_at) VALUES ('metadata', now()), ('rentals', to_timestamp(0))")
 }
 
 export async function down(pgm: MigrationBuilder): Promise<void> {

--- a/src/migrations/1654545715004_rentals.ts
+++ b/src/migrations/1654545715004_rentals.ts
@@ -57,13 +57,20 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
     rental_id: { type: "uuid", notNull: true, unique: false, references: "rentals_listings(id)", onDelete: "CASCADE" },
   })
 
+  pgm.createTable("updates", {
+    id: { type: "uuid", primaryKey: true, default: pgm.func("uuid_generate_v4()") },
+    updated_at: { type: "timestamp", notNull: true, default: pgm.func("to_timestamp(0)") },
+  })
+
   pgm.createIndex("periods", "rental_id")
   pgm.createIndex("periods", "min_days")
   pgm.createIndex("periods", "max_days")
   pgm.createIndex("periods", "price_per_day")
   pgm.createIndex("rentals", "metadata_id")
+  pgm.createIndex("rentals", "signature")
   // Ensure that there won't be more than one open rental per token
   pgm.createIndex("rentals", ["token_id", "contract_address", "status"], { where: "status = 'open'", unique: true })
+  pgm.createIndex("updates", "updated_at")
 }
 
 export async function down(pgm: MigrationBuilder): Promise<void> {
@@ -72,4 +79,5 @@ export async function down(pgm: MigrationBuilder): Promise<void> {
   pgm.dropTable("rentals_offers")
   pgm.dropTable("rentals_listing")
   pgm.dropTable("metadata")
+  pgm.dropType("status")
 }

--- a/src/ports/job/component.ts
+++ b/src/ports/job/component.ts
@@ -3,7 +3,9 @@ import { IJobComponent, JobOptions } from "./types"
 
 export function createJobComponent(
   components: Pick<AppComponents, "logs">,
+  /** The function to execute as a job. Admits asynchronous functions. */
   job: () => any,
+  /** The amount of time to wait between jobs */
   onTime: number,
   { repeat = true, startupDelay = 0, onError = () => undefined, onFinish = () => undefined }: JobOptions = {
     repeat: true,
@@ -45,7 +47,6 @@ export function createJobComponent(
   async function runJob() {
     await sleep(startupDelay)
     while (!shouldStop) {
-      await sleep(onTime)
       try {
         runningJob = job()
         await runningJob
@@ -56,6 +57,7 @@ export function createJobComponent(
       if (!repeat) {
         break
       }
+      await sleep(onTime)
     }
     await onFinish()
     logger.info("[Stopped]")

--- a/src/ports/rentals/component.ts
+++ b/src/ports/rentals/component.ts
@@ -332,10 +332,7 @@ export function createRentalsComponent(
 
     const promisesOfUpdate: Promise<any>[] = []
     // Update metadata
-    console.log("Indexer NFT last update", indexerNFTLastUpdate)
-    console.log("NFT DB data", rentalData.metadata_updated_at.getTime())
     if (indexerNFTLastUpdate > rentalData.metadata_updated_at.getTime()) {
-      console.log("Updating metadata")
       logger.info(`[Refresh][Update metadata][${rentalId}]`)
       promisesOfUpdate.push(
         database.query(
@@ -361,7 +358,7 @@ export function createRentalsComponent(
       )
     }
 
-    console.log("Updated promises", await Promise.all(promisesOfUpdate))
+    await Promise.all(promisesOfUpdate)
 
     // Return the updated rental listing
     const result =

--- a/src/ports/rentals/errors.ts
+++ b/src/ports/rentals/errors.ts
@@ -17,7 +17,7 @@ export class RentalAlreadyExists extends Error {
 }
 
 export class RentalNotFound extends Error {
-  constructor(public id: string) {
+  constructor(public id?: string) {
     super("The rental was not found")
   }
 }

--- a/src/ports/rentals/graph.ts
+++ b/src/ports/rentals/graph.ts
@@ -1,0 +1,46 @@
+export function buildQueryParameters<T extends Record<string, any>>(
+  filterBy?: Partial<T>,
+  first?: number,
+  orderBy?: keyof T,
+  orderDirection?: "desc" | "asc"
+): { querySignature: string; queryVariables: string } {
+  let querySignature = ""
+  let queryVariables = ""
+
+  if (first) {
+    querySignature += `first: ${first} `
+  }
+  if (orderBy) {
+    querySignature += `orderBy: ${orderBy.toString()} `
+  }
+  if (orderDirection) {
+    querySignature += `orderDirection: ${orderDirection} `
+  }
+  if (filterBy) {
+    querySignature += `where: { ${Object.keys(filterBy)
+      .filter((key) => filterBy[key] !== undefined)
+      .reduce((acc, key) => `${acc} ${key}: $${key}`, "")} }`
+    queryVariables += Object.entries(filterBy)
+      .filter(([_, value]) => value !== undefined)
+      .map(([key, value]) => {
+        let type: string
+        if (typeof value === "string") {
+          type = "String"
+        } else if (typeof value === "number") {
+          type = "Int"
+        } else if (typeof value === "boolean") {
+          type = "Boolean"
+        } else {
+          throw new Error("Can't parse filter by type")
+        }
+
+        return `$${key}: ${type}`
+      })
+      .join(" ")
+  }
+
+  return {
+    querySignature,
+    queryVariables,
+  }
+}

--- a/src/ports/rentals/types.ts
+++ b/src/ports/rentals/types.ts
@@ -10,7 +10,8 @@ export type IRentalsComponent = {
     limit: number
     filterBy: FilterBy | null
   }): Promise<DBGetRentalListing[]>
-  updateRentalListings(): Promise<void>
+  updateRentalsListings(): Promise<void>
+  updateMetadata(): Promise<void>
 }
 
 export type RentalListingCreation = {
@@ -36,6 +37,11 @@ export enum Status {
   OPEN = "open",
   CANCELLED = "cancelled",
   EXECUTED = "executed",
+}
+
+export enum UpdateType {
+  METADATA = "metadata",
+  RENTALS = "rentals",
 }
 
 export type DBMetadata = {
@@ -104,6 +110,8 @@ export type NFT = {
   createdAt: string
   /** Timestamp when the NFT was updated for the last time in seconds since epoch */
   updatedAt: string
+  /** Wether the NFT is LAND or not */
+  searchIsLand: boolean
 }
 
 export enum FilterByCategory {

--- a/src/ports/rentals/types.ts
+++ b/src/ports/rentals/types.ts
@@ -10,6 +10,7 @@ export type IRentalsComponent = {
     limit: number
     filterBy: FilterBy | null
   }): Promise<DBGetRentalListing[]>
+  updateRentalListings(): Promise<void>
 }
 
 export type RentalListingCreation = {
@@ -150,6 +151,8 @@ export type IndexerRental = {
   id: string
   /** The contract address of the LAND */
   contractAddress: string
+  /** The contract address of the rentals contract */
+  rentalContractAddress: string
   /** The token id of the LAND */
   tokenId: string
   /** The address of the lessor of the LAND */

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,7 +29,8 @@ export type BaseComponents = {
   rentalsSubgraph: ISubgraphComponent
   schemaValidator: ISchemaValidatorComponent
   rentals: IRentalsComponent
-  job: IJobComponent
+  updateMetadataJob: IJobComponent
+  updateRentalsListingsJob: IJobComponent
 }
 
 // components used in runtime

--- a/test/components.ts
+++ b/test/components.ts
@@ -62,18 +62,20 @@ export async function initComponents(): Promise<TestComponents> {
     await config.requireString("RENTALS_SUBGRAPH_URL")
   )
   const database = await createPgComponent({ logs, config, metrics })
-  const rentals = createRentalsComponent({
+  const rentals = await createRentalsComponent({
     logs,
     database,
     marketplaceSubgraph,
     rentalsSubgraph,
+    config,
   })
   const schemaValidator = await createSchemaValidatorComponent()
   const statusChecks = await createStatusCheckComponent({ server, config })
   // Mock the start function to avoid connecting to a local database
   jest.spyOn(database, "start").mockResolvedValue()
 
-  const job = createTestJobComponent()
+  const updateMetadataJob = createTestJobComponent()
+  const updateRentalsListingsJob = createTestJobComponent()
 
   return {
     config,
@@ -88,7 +90,8 @@ export async function initComponents(): Promise<TestComponents> {
     schemaValidator,
     rentals,
     localFetch: await createLocalFetchCompoment(config),
-    job,
+    updateMetadataJob,
+    updateRentalsListingsJob,
   }
 }
 
@@ -125,16 +128,26 @@ export function createTestSubgraphComponent({ query = jest.fn() } = { query: jes
 }
 
 export function createTestRentalsComponent(
-  { createRentalListing = jest.fn(), getRentalsListings = jest.fn(), refreshRentalListing = jest.fn() } = {
+  {
+    createRentalListing = jest.fn(),
+    getRentalsListings = jest.fn(),
+    refreshRentalListing = jest.fn(),
+    updateMetadata = jest.fn(),
+    updateRentalsListings = jest.fn(),
+  } = {
     createRentalListing: jest.fn(),
     getRentalsListings: jest.fn(),
     refreshRentalListing: jest.fn(),
+    updateMetadata: jest.fn(),
+    updateRentalsListings: jest.fn(),
   }
 ): IRentalsComponent {
   return {
     getRentalsListings,
     createRentalListing,
     refreshRentalListing,
+    updateMetadata,
+    updateRentalsListings,
   }
 }
 

--- a/test/components.ts
+++ b/test/components.ts
@@ -1,7 +1,10 @@
 // This file is the "test-environment" analogous for src/components.ts
 // Here we define the test components to be used in the testing environment
 
-import { createRunner, createLocalFetchCompoment } from "@well-known-components/test-helpers"
+import {
+  createRunner,
+  createLocalFetchCompoment as createLocalFetchComponent,
+} from "@well-known-components/test-helpers"
 import { ILoggerComponent } from "@well-known-components/interfaces"
 import { createSubgraphComponent, ISubgraphComponent } from "@well-known-components/thegraph-component"
 import { createPgComponent, IPgComponent } from "@well-known-components/pg-component"
@@ -89,7 +92,7 @@ export async function initComponents(): Promise<TestComponents> {
     rentalsSubgraph,
     schemaValidator,
     rentals,
-    localFetch: await createLocalFetchCompoment(config),
+    localFetch: await createLocalFetchComponent(config),
     updateMetadataJob,
     updateRentalsListingsJob,
   }

--- a/test/setupTests.js
+++ b/test/setupTests.js
@@ -1,0 +1,13 @@
+const path = require("path")
+const { existsSync, copyFileSync } = require("fs")
+
+const defaultEnvironmentFilePath = path.join(__dirname, "../.env.default")
+const environmentFilePath = path.join(__dirname, "../.env")
+
+if (!existsSync(environmentFilePath)) {
+  if (!existsSync(defaultEnvironmentFilePath)) {
+    throw new Error("An .env file is needed to run the tests")
+  }
+
+  copyFileSync(defaultEnvironmentFilePath, environmentFilePath)
+}

--- a/test/setupTests.js
+++ b/test/setupTests.js
@@ -1,13 +1,16 @@
 const path = require("path")
 const { existsSync, copyFileSync } = require("fs")
 
-const defaultEnvironmentFilePath = path.join(__dirname, "../.env.default")
-const environmentFilePath = path.join(__dirname, "../.env")
+module.exports = async function () {
+  const defaultEnvironmentFilePath = path.join(__dirname, "../.env.default")
+  const environmentFilePath = path.join(__dirname, "../.env")
+  console.log("Running setup function", defaultEnvironmentFilePath, environmentFilePath)
 
-if (!existsSync(environmentFilePath)) {
-  if (!existsSync(defaultEnvironmentFilePath)) {
-    throw new Error("An .env file is needed to run the tests")
+  if (!existsSync(environmentFilePath)) {
+    if (!existsSync(defaultEnvironmentFilePath)) {
+      throw new Error("An .env file is needed to run the tests")
+    }
+
+    copyFileSync(defaultEnvironmentFilePath, environmentFilePath)
   }
-
-  copyFileSync(defaultEnvironmentFilePath, environmentFilePath)
 }

--- a/test/unit/schema-validator.spec.ts
+++ b/test/unit/schema-validator.spec.ts
@@ -27,7 +27,8 @@ beforeEach(async () => {
     marketplaceSubgraph: createTestSubgraphComponent(),
     rentalsSubgraph: createTestSubgraphComponent(),
     schemaValidator: createSchemaValidatorComponent(),
-    job: createTestJobComponent(),
+    updateMetadataJob: createTestJobComponent(),
+    updateRentalsListingsJob: createTestJobComponent(),
   }
   middleware = createSchemaValidatorComponent().withSchemaValidatorMiddleware({
     type: "object",


### PR DESCRIPTION
This PR introduces two new jobs, the metadata and the rental jobs:
- Metadata job: updates the NFT metadata in the database and closes rentals if a NFT changed owners.
- Rentals jobs: updates rentals listings by checking its blockchain counterpart, inserts listings that were created through the rentals contract and cancels all listings that have expired.