### PR TITLE
feat: Add tokenId, network and contract addresses filters

### DIFF
--- a/src/controllers/handlers/rentals-handlers.ts
+++ b/src/controllers/handlers/rentals-handlers.ts
@@ -1,3 +1,4 @@
+import { Network } from "@dcl/schemas"
 import * as authorizationMiddleware from "decentraland-crypto-middleware"
 import { fromDBGetRentalsListingsToRentalListings, fromDBInsertedRentalListingToRental } from "../../adapters/rentals"
 import { getPaginationParams, getTypedStringQueryParameter, InvalidParameterError } from "../../logic/http"
@@ -34,6 +35,10 @@ export async function getRentalsListingsHandler(
       lessor: url.searchParams.get("lessor") ?? undefined,
       tenant: url.searchParams.get("tenant") ?? undefined,
       status: getTypedStringQueryParameter(Object.values(Status), url.searchParams, "status") ?? undefined,
+      tokenId: url.searchParams.get("tokenId") ?? undefined,
+      contractAddresses: url.searchParams.getAll("contractAddresses") ?? undefined,
+      network:
+        (getTypedStringQueryParameter(Object.values(Network), url.searchParams, "network") as Network) ?? undefined,
     }
     const rentalListings = await rentals.getRentalsListings({ sortBy, sortDirection, page, limit, filterBy })
     return {

--- a/src/ports/rentals/component.ts
+++ b/src/ports/rentals/component.ts
@@ -268,6 +268,12 @@ export async function createRentalsComponent(
     const filterBySearchText = filterBy?.text
       ? SQL`AND metadata.search_text ILIKE '%' || ${filterBy.text} || '%'\n`
       : ""
+    const filterByTokenId = filterBy?.tokenId ? SQL`AND rentals.token_id = ${filterBy.tokenId}\n` : ""
+    const filterByContractAddress =
+      filterBy?.contractAddresses && filterBy.contractAddresses.length > 0
+        ? SQL`AND rentals.contract_address = ANY(${filterBy.contractAddresses})\n`
+        : ""
+    const filterByNetwork = filterBy?.network ? SQL`AND rentals.network = ${filterBy.network}\n` : ""
 
     let sortByQuery: SQLStatement | string = `ORDER BY rentals.created_at ${sortDirectionParam}\n`
     switch (sortByParam) {
@@ -297,6 +303,9 @@ export async function createRentalsComponent(
       periods.rental_id = rentals.id\n`
     query.append(filterByCategory)
     query.append(filterByStatus)
+    query.append(filterByTokenId)
+    query.append(filterByContractAddress)
+    query.append(filterByNetwork)
     query.append(filterByLessor)
     query.append(filterByTenant)
     query.append(

--- a/src/ports/rentals/types.ts
+++ b/src/ports/rentals/types.ts
@@ -3,15 +3,17 @@ import { ChainId, Network, NFTCategory } from "@dcl/schemas"
 export type IRentalsComponent = {
   createRentalListing(rental: RentalListingCreation, lessorAddress: string): Promise<DBInsertedRentalListing>
   refreshRentalListing(rentalId: string): Promise<DBGetRentalListing>
-  getRentalsListings(params: {
-    sortBy: RentalsListingsSortBy | null
-    sortDirection: SortDirection | null
-    page: number
-    limit: number
-    filterBy: FilterBy | null
-  }): Promise<DBGetRentalListing[]>
+  getRentalsListings(params: GetRentalListingParameters): Promise<DBGetRentalListing[]>
   updateRentalsListings(): Promise<void>
   updateMetadata(): Promise<void>
+}
+
+export type GetRentalListingParameters = {
+  sortBy: RentalsListingsSortBy | null
+  sortDirection: SortDirection | null
+  page: number
+  limit: number
+  filterBy: FilterBy | null
 }
 
 export type RentalListingCreation = {
@@ -132,6 +134,9 @@ export type FilterBy = {
   periods?: FilterByPeriod
   lessor?: string
   tenant?: string
+  tokenId?: string
+  contractAddresses?: string[]
+  network?: Network
 }
 
 export enum SortDirection {

--- a/test/unit/rentals-component.spec.ts
+++ b/test/unit/rentals-component.spec.ts
@@ -564,30 +564,63 @@ describe("when getting rental listings", () => {
   })
 
   describe("and the contract addresses filter is set", () => {
+    let contractAddresses: string[]
     beforeEach(() => {
       dbGetRentalListings = []
       dbQueryMock.mockResolvedValueOnce({ rows: dbGetRentalListings })
     })
 
-    it("should have made the query to get the listings with the contract addresses condition", async () => {
-      await expect(
-        rentalsComponent.getRentalsListings({
-          page: 0,
-          limit: 10,
-          sortBy: null,
-          sortDirection: null,
-          filterBy: {
-            contractAddresses: ["aContractAddress", "anotherContractAddress"],
-          },
-        })
-      ).resolves.toEqual(dbGetRentalListings)
+    describe("and the filter is set with an empty array of addresses", () => {
+      beforeEach(() => {
+        contractAddresses = []
+      })
 
-      expect(dbQueryMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          strings: expect.arrayContaining([expect.stringContaining("AND rentals.contract_address = ANY(")]),
-          values: [["aContractAddress", "anotherContractAddress"], 10, 0],
-        })
-      )
+      it("should not have made the query to get the listings with the contract addresses condition", async () => {
+        await expect(
+          rentalsComponent.getRentalsListings({
+            page: 0,
+            limit: 10,
+            sortBy: null,
+            sortDirection: null,
+            filterBy: {
+              contractAddresses,
+            },
+          })
+        ).resolves.toEqual(dbGetRentalListings)
+
+        expect(dbQueryMock).not.toHaveBeenCalledWith(
+          expect.objectContaining({
+            strings: expect.arrayContaining([expect.stringContaining("AND rentals.contract_address = ANY(")]),
+          })
+        )
+      })
+    })
+
+    describe("and the filter is set with addresses", () => {
+      beforeEach(() => {
+        contractAddresses = ["aContractAddress", "anotherContractAddress"]
+      })
+
+      it("should have made the query to get the listings with the contract addresses condition", async () => {
+        await expect(
+          rentalsComponent.getRentalsListings({
+            page: 0,
+            limit: 10,
+            sortBy: null,
+            sortDirection: null,
+            filterBy: {
+              contractAddresses: ["aContractAddress", "anotherContractAddress"],
+            },
+          })
+        ).resolves.toEqual(dbGetRentalListings)
+
+        expect(dbQueryMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            strings: expect.arrayContaining([expect.stringContaining("AND rentals.contract_address = ANY(")]),
+            values: [["aContractAddress", "anotherContractAddress"], 10, 0],
+          })
+        )
+      })
     })
   })
 

--- a/test/unit/rentals-component.spec.ts
+++ b/test/unit/rentals-component.spec.ts
@@ -535,6 +535,90 @@ describe("when getting rental listings", () => {
     })
   })
 
+  describe("and the tokenId filter is set", () => {
+    beforeEach(() => {
+      dbGetRentalListings = []
+      dbQueryMock.mockResolvedValueOnce({ rows: dbGetRentalListings })
+    })
+
+    it("should have made the query to get the listings with the tokenId condition", async () => {
+      await expect(
+        rentalsComponent.getRentalsListings({
+          page: 0,
+          limit: 10,
+          sortBy: null,
+          sortDirection: null,
+          filterBy: {
+            tokenId: "aTokenId",
+          },
+        })
+      ).resolves.toEqual(dbGetRentalListings)
+
+      expect(dbQueryMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          strings: expect.arrayContaining([expect.stringContaining("AND rentals.token_id = ")]),
+          values: ["aTokenId", 10, 0],
+        })
+      )
+    })
+  })
+
+  describe("and the contract addresses filter is set", () => {
+    beforeEach(() => {
+      dbGetRentalListings = []
+      dbQueryMock.mockResolvedValueOnce({ rows: dbGetRentalListings })
+    })
+
+    it("should have made the query to get the listings with the contract addresses condition", async () => {
+      await expect(
+        rentalsComponent.getRentalsListings({
+          page: 0,
+          limit: 10,
+          sortBy: null,
+          sortDirection: null,
+          filterBy: {
+            contractAddresses: ["aContractAddress", "anotherContractAddress"],
+          },
+        })
+      ).resolves.toEqual(dbGetRentalListings)
+
+      expect(dbQueryMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          strings: expect.arrayContaining([expect.stringContaining("AND rentals.contract_address = ANY(")]),
+          values: [["aContractAddress", "anotherContractAddress"], 10, 0],
+        })
+      )
+    })
+  })
+
+  describe("and the network filter is set", () => {
+    beforeEach(() => {
+      dbGetRentalListings = []
+      dbQueryMock.mockResolvedValueOnce({ rows: dbGetRentalListings })
+    })
+
+    it("should have made the query to get the listings with the network condition", async () => {
+      await expect(
+        rentalsComponent.getRentalsListings({
+          page: 0,
+          limit: 10,
+          sortBy: null,
+          sortDirection: null,
+          filterBy: {
+            network: Network.ETHEREUM,
+          },
+        })
+      ).resolves.toEqual(dbGetRentalListings)
+
+      expect(dbQueryMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          strings: expect.arrayContaining([expect.stringContaining("AND rentals.network = ")]),
+          values: [Network.ETHEREUM, 10, 0],
+        })
+      )
+    })
+  })
+
   describe("and there are no filters to query for", () => {
     beforeEach(() => {
       dbGetRentalListings = []


### PR DESCRIPTION
This PR adds the token id, network and contract addresses filters.