### PR TITLE
feat: Add support for retrieving rentals by nft id

### DIFF
--- a/src/adapters/rentals/rentals.ts
+++ b/src/adapters/rentals/rentals.ts
@@ -6,8 +6,9 @@ import { Period, RentalListing } from "./types"
 export function fromDBInsertedRentalListingToRental(DBRental: DBInsertedRentalListing): RentalListing {
   return {
     id: DBRental.id,
+    nftId: DBRental.metadata_id,
     category: DBRental.category,
-    search_text: DBRental.search_text,
+    searchText: DBRental.search_text,
     network: DBRental.network,
     chainId: DBRental.chain_id,
     expiration: DBRental.expiration.getTime(),
@@ -55,9 +56,10 @@ export function fromDBGetRentalsListingsToRentalListings(DBRentals: DBGetRentalL
   return DBRentals.map((rental) => ({
     id: rental.id,
     category: rental.category,
-    search_text: rental.search_text,
+    searchText: rental.search_text,
     network: rental.network,
     chainId: rental.chain_id,
+    nftId: rental.metadata_id,
     expiration: rental.expiration.getTime(),
     signature: rental.signature,
     nonces: rental.nonces,
@@ -71,9 +73,9 @@ export function fromDBGetRentalsListingsToRentalListings(DBRentals: DBGetRentalL
     updatedAt: rental.updated_at.getTime(),
     startedAt: rental.started_at ? rental.started_at.getTime() : null,
     periods: rental.periods.map((period) => ({
-      minDays: period[1],
-      maxDays: period[2],
-      pricePerDay: period[3],
+      minDays: Number(period[0]),
+      maxDays: Number(period[1]),
+      pricePerDay: period[2],
     })),
   }))
 }

--- a/src/adapters/rentals/types.ts
+++ b/src/adapters/rentals/types.ts
@@ -4,7 +4,7 @@ import { Status } from "../../ports/rentals"
 export type RentalListing = {
   id: string
   category: NFTCategory
-  search_text: string
+  searchText: string
   network: Network
   chainId: ChainId
   /** UTC timestamp in milliseconds since epoch of the signature's expiration */
@@ -24,6 +24,8 @@ export type RentalListing = {
   /** UTC timestamp in milliseconds since epoch of the time the rental started */
   startedAt: number | null
   periods: Period[]
+  /** The NFT token id */
+  nftId: string
 }
 
 export type Period = {

--- a/src/components.ts
+++ b/src/components.ts
@@ -18,10 +18,8 @@ export async function initComponents(): Promise<AppComponents> {
   const MARKETPLACE_SUBGRAPH_URL = await config.requireString("MARKETPLACE_SUBGRAPH_URL")
   const RENTALS_SUBGRAPH_URL = await config.requireString("RENTALS_SUBGRAPH_URL")
   const LOG_LEVEL = await config.requireString("LOG_LEVEL")
-  // const thirtySeconds = 30 * 1000
-  // const fiveMinutes = 5 * 60 * 1000
-  const thirtySeconds = 2000 * 1000
-  const fiveMinutes = 5000 * 60 * 1000
+  const thirtySeconds = 30 * 1000
+  const fiveMinutes = 5 * 60 * 1000
 
   const logs = createLogComponent({ config: { logLevel: LOG_LEVEL } })
   const server = await createServerComponent<GlobalContext>({ config, logs }, {})

--- a/src/components.ts
+++ b/src/components.ts
@@ -18,8 +18,10 @@ export async function initComponents(): Promise<AppComponents> {
   const MARKETPLACE_SUBGRAPH_URL = await config.requireString("MARKETPLACE_SUBGRAPH_URL")
   const RENTALS_SUBGRAPH_URL = await config.requireString("RENTALS_SUBGRAPH_URL")
   const LOG_LEVEL = await config.requireString("LOG_LEVEL")
-  const thirtySeconds = 30 * 1000
-  const fiveMinutes = 5 * 60 * 1000
+  // const thirtySeconds = 30 * 1000
+  // const fiveMinutes = 5 * 60 * 1000
+  const thirtySeconds = 2000 * 1000
+  const fiveMinutes = 5000 * 60 * 1000
 
   const logs = createLogComponent({ config: { logLevel: LOG_LEVEL } })
   const server = await createServerComponent<GlobalContext>({ config, logs }, {})

--- a/src/controllers/handlers/rentals-handlers.ts
+++ b/src/controllers/handlers/rentals-handlers.ts
@@ -3,6 +3,7 @@ import * as authorizationMiddleware from "decentraland-crypto-middleware"
 import { fromDBGetRentalsListingsToRentalListings, fromDBInsertedRentalListingToRental } from "../../adapters/rentals"
 import { getPaginationParams, getTypedStringQueryParameter, InvalidParameterError } from "../../logic/http"
 import {
+  FilterBy,
   FilterByCategory,
   NFTNotFound,
   RentalAlreadyExists,
@@ -24,11 +25,10 @@ export async function getRentalsListingsHandler(
   } = context
 
   const { page, limit } = getPaginationParams(url.searchParams)
-
   try {
     const sortBy = getTypedStringQueryParameter(Object.values(RentalsListingsSortBy), url.searchParams, "sortBy")
     const sortDirection = getTypedStringQueryParameter(Object.values(SortDirection), url.searchParams, "sortDirection")
-    const filterBy = {
+    const filterBy: FilterBy = {
       category:
         getTypedStringQueryParameter(Object.values(FilterByCategory), url.searchParams, "category") ?? undefined,
       text: url.searchParams.get("text") ?? undefined,
@@ -36,7 +36,8 @@ export async function getRentalsListingsHandler(
       tenant: url.searchParams.get("tenant") ?? undefined,
       status: getTypedStringQueryParameter(Object.values(Status), url.searchParams, "status") ?? undefined,
       tokenId: url.searchParams.get("tokenId") ?? undefined,
-      contractAddresses: url.searchParams.getAll("contractAddresses") ?? undefined,
+      contractAddresses: url.searchParams.getAll("contractAddresses"),
+      nftIds: url.searchParams.getAll("nftIds"),
       network:
         (getTypedStringQueryParameter(Object.values(Network), url.searchParams, "network") as Network) ?? undefined,
     }

--- a/src/ports/rentals/types.ts
+++ b/src/ports/rentals/types.ts
@@ -87,10 +87,11 @@ export type DBPeriods = {
 export type DBGetRentalListing = DBRental &
   DBRentalListing &
   DBMetadata & {
-    /** An array containing [id, min_days, max_days, price_per_day] */
-    periods: [string, number, number, string][]
+    /** An array containing [min_days, max_days, price_per_day] */
+    periods: [string, string, string][]
     metadata_created_at: Date
     rentals_listings_count: string
+    metadata_id: string
   }
 export type DBInsertedRentalListing = DBRental &
   DBRentalListing & { periods: Omit<DBPeriods, "id">[] } & Pick<DBMetadata, "category" | "search_text">
@@ -137,6 +138,7 @@ export type FilterBy = {
   tokenId?: string
   contractAddresses?: string[]
   network?: Network
+  nftIds?: string[]
 }
 
 export enum SortDirection {

--- a/test/unit/rentals-adapters.spec.ts
+++ b/test/unit/rentals-adapters.spec.ts
@@ -45,8 +45,9 @@ describe("when transforming a DB inserted rental listing to a rental listing", (
     }
     rentalListing = {
       id: dbInsertedRentalListing.id,
+      nftId: dbInsertedRentalListing.metadata_id,
       category: dbInsertedRentalListing.category,
-      search_text: dbInsertedRentalListing.search_text,
+      searchText: dbInsertedRentalListing.search_text,
       network: dbInsertedRentalListing.network,
       chainId: dbInsertedRentalListing.chain_id,
       expiration: dbInsertedRentalListing.expiration.getTime(),
@@ -101,17 +102,17 @@ describe("when transforming DB retrieved rental listings to rental listings", ()
         created_at: new Date("2022-06-13T22:56:36.755Z"),
         updated_at: new Date("2022-06-13T22:56:36.755Z"),
         started_at: new Date("2022-06-14T22:56:36.755Z"),
-        periods: [["anId", 30, 50, "1000000000"]],
+        periods: [["30", "50", "1000000000"]],
         metadata_created_at: new Date(),
         rentals_listings_count: "1",
       },
     ]
-
     rentalListings = [
       {
         id: dbGetRentalListings[0].id,
+        nftId: dbGetRentalListings[0].metadata_id,
         category: dbGetRentalListings[0].category,
-        search_text: dbGetRentalListings[0].search_text,
+        searchText: dbGetRentalListings[0].search_text,
         network: dbGetRentalListings[0].network,
         chainId: dbGetRentalListings[0].chain_id,
         expiration: dbGetRentalListings[0].expiration.getTime(),
@@ -128,9 +129,9 @@ describe("when transforming DB retrieved rental listings to rental listings", ()
         startedAt: dbGetRentalListings[0].started_at!.getTime(),
         periods: [
           {
-            minDays: dbGetRentalListings[0].periods[0][1],
-            maxDays: dbGetRentalListings[0].periods[0][2],
-            pricePerDay: dbGetRentalListings[0].periods[0][3],
+            minDays: Number(dbGetRentalListings[0].periods[0][0]),
+            maxDays: Number(dbGetRentalListings[0].periods[0][1]),
+            pricePerDay: dbGetRentalListings[0].periods[0][2],
           },
         ],
       },
@@ -150,8 +151,9 @@ describe("when transforming a rental creation to a contract rental listing", () 
   beforeEach(() => {
     rentalCreation = {
       id: "5884c820-2612-409c-bb9e-a01e8d3569e9",
+      nftId: "aNftId",
       category: NFTCategory.PARCEL,
-      search_text: "someText",
+      searchText: "someText",
       network: Network.ETHEREUM,
       chainId: ChainId.ETHEREUM_GOERLI,
       expiration: new Date().getTime(),

--- a/test/unit/rentals-handler.spec.ts
+++ b/test/unit/rentals-handler.spec.ts
@@ -325,7 +325,7 @@ describe("when getting rental listings", () => {
           created_at: new Date("2022-06-13T22:56:36.755Z"),
           updated_at: new Date("2022-06-13T22:56:36.755Z"),
           started_at: null,
-          periods: [["anId", 30, 50, "1000000000"]],
+          periods: [["30", "50", "1000000000"]],
           metadata_created_at: new Date(),
           rentals_listings_count: "1",
         },
@@ -333,8 +333,9 @@ describe("when getting rental listings", () => {
       rentalListings = [
         {
           id: dbRentalListings[0].id,
+          nftId: dbRentalListings[0].metadata_id,
           category: dbRentalListings[0].category,
-          search_text: dbRentalListings[0].search_text,
+          searchText: dbRentalListings[0].search_text,
           network: dbRentalListings[0].network,
           chainId: dbRentalListings[0].chain_id,
           expiration: dbRentalListings[0].expiration.getTime(),
@@ -351,9 +352,9 @@ describe("when getting rental listings", () => {
           startedAt: null,
           periods: [
             {
-              minDays: dbRentalListings[0].periods[0][1],
-              maxDays: dbRentalListings[0].periods[0][2],
-              pricePerDay: dbRentalListings[0].periods[0][3],
+              minDays: Number(dbRentalListings[0].periods[0][0]),
+              maxDays: Number(dbRentalListings[0].periods[0][1]),
+              pricePerDay: dbRentalListings[0].periods[0][2],
             },
           ],
         },
@@ -472,14 +473,15 @@ describe("when refreshing a rental listing", () => {
         created_at: new Date("2022-06-13T22:56:36.755Z"),
         updated_at: new Date("2022-06-13T22:56:36.755Z"),
         started_at: null,
-        periods: [["anId", 30, 50, "1000000000"]],
+        periods: [["30", "50", "1000000000"]],
         metadata_created_at: new Date(),
         rentals_listings_count: "1",
       }
       rentalListing = {
         id: dbRentalListing.id,
+        nftId: dbRentalListing.metadata_id,
         category: dbRentalListing.category,
-        search_text: dbRentalListing.search_text,
+        searchText: dbRentalListing.search_text,
         network: dbRentalListing.network,
         chainId: dbRentalListing.chain_id,
         expiration: dbRentalListing.expiration.getTime(),
@@ -496,9 +498,9 @@ describe("when refreshing a rental listing", () => {
         startedAt: null,
         periods: [
           {
-            minDays: dbRentalListing.periods[0][1],
-            maxDays: dbRentalListing.periods[0][2],
-            pricePerDay: dbRentalListing.periods[0][3],
+            minDays: Number(dbRentalListing.periods[0][0]),
+            maxDays: Number(dbRentalListing.periods[0][1]),
+            pricePerDay: dbRentalListing.periods[0][2],
           },
         ],
       }

--- a/test/unit/rentals-logic.spec.ts
+++ b/test/unit/rentals-logic.spec.ts
@@ -63,7 +63,7 @@ describe("when verifying the rentals listings signature", () => {
     let otherAddress: string
 
     beforeEach(async () => {
-      otherAddress = await ethers.Wallet.createRandom().getAddress()
+      otherAddress = "0x165cd37b4c644c2921454429e7f9358d18a45e14"
       contractRentalListing = {
         signer: otherAddress,
         contractAddress: values.contractAddress,


### PR DESCRIPTION
This PR implements the capability to retrieve rentals by nft ids.
It also does the following:
- Renames `search_text` to `searchText`.
- Adds the `nftId` property to the returned rentals.
- Fixes the get rentals query so they return correctly the prices of the periods.