### PR TITLE
fix: Change default nonces to be big numbers

### DIFF
--- a/src/ports/rentals/component.ts
+++ b/src/ports/rentals/component.ts
@@ -594,7 +594,7 @@ export async function createRentalsComponent(
               }
 
               // Create rental listing
-              const defaultNonces = ["", "", ""]
+              const defaultNonces = ["0", "0", "0"]
               const startedAt = new Date(fromSecondsToMilliseconds(Number(rental.startedAt)))
               const {
                 rows: [insertedRental],

--- a/test/unit/rentals-component.spec.ts
+++ b/test/unit/rentals-component.spec.ts
@@ -77,7 +77,7 @@ describe("when creating a rental listing", () => {
       contractAddress: "0x0",
       tokenId: "0",
       expiration: Date.now() + 2000000,
-      nonces: ["0x0", "0x0", "0x0"],
+      nonces: ["0", "0", "0"],
       periods: [
         {
           pricePerDay: "10000",
@@ -1607,7 +1607,7 @@ describe("when updating the rental listings", () => {
                 ChainId.ETHEREUM_GOERLI,
                 new Date(0),
                 rentalFromIndexer.signature,
-                ["", "", ""],
+                ["0", "0", "0"],
                 rentalFromIndexer.tokenId,
                 rentalFromIndexer.contractAddress,
                 rentalFromIndexer.rentalContractAddress,
@@ -1684,7 +1684,7 @@ describe("when updating the rental listings", () => {
                 ChainId.ETHEREUM_GOERLI,
                 new Date(0),
                 rentalFromIndexer.signature,
-                ["", "", ""],
+                ["0", "0", "0"],
                 rentalFromIndexer.tokenId,
                 rentalFromIndexer.contractAddress,
                 rentalFromIndexer.rentalContractAddress,


### PR DESCRIPTION
This PR changes the default nonces to be big numbers as nonces are `uint256s`.
When implementing the job to cancel cancelled listings, a migration will be needed to migrate from text to `numeric(78)`.