### PR TITLE
feat: Add support for the claimed status

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "template-server",
       "dependencies": {
-        "@dcl/schemas": "^5.17.1",
+        "@dcl/schemas": "^5.26.0",
         "@well-known-components/env-config-provider": "^1.1.1",
         "@well-known-components/http-server": "^1.1.4",
         "@well-known-components/interfaces": "^1.1.1",
@@ -662,9 +662,9 @@
       }
     },
     "node_modules/@dcl/schemas": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.17.1.tgz",
-      "integrity": "sha512-4UgDwSOQOfu+n2iHz/0qOwRqBH+/6aC7O/2LYCr0/sbT54RDiAc0sks3iJyFI9qR7+mFaxT1GCCCQaeRJWMvMg==",
+      "version": "5.26.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.26.0.tgz",
+      "integrity": "sha512-/4EHGtjpdiS+z3gVec6kp7xXK1sDt2X4DCUHJWFrgM6jRq77cB2Y5lTH5PUqbgfkdJvAZ/Ogh5pSdCT3aH+eOg==",
       "dependencies": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",
@@ -9633,9 +9633,9 @@
       }
     },
     "@dcl/schemas": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.17.1.tgz",
-      "integrity": "sha512-4UgDwSOQOfu+n2iHz/0qOwRqBH+/6aC7O/2LYCr0/sbT54RDiAc0sks3iJyFI9qR7+mFaxT1GCCCQaeRJWMvMg==",
+      "version": "5.26.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.26.0.tgz",
+      "integrity": "sha512-/4EHGtjpdiS+z3gVec6kp7xXK1sDt2X4DCUHJWFrgM6jRq77cB2Y5lTH5PUqbgfkdJvAZ/Ogh5pSdCT3aH+eOg==",
       "requires": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "semi": false
   },
   "dependencies": {
-    "@dcl/schemas": "^5.17.1",
+    "@dcl/schemas": "^5.26.0",
     "@well-known-components/env-config-provider": "^1.1.1",
     "@well-known-components/http-server": "^1.1.4",
     "@well-known-components/interfaces": "^1.1.1",

--- a/src/adapters/rentals/rentals.ts
+++ b/src/adapters/rentals/rentals.ts
@@ -1,6 +1,6 @@
 import { RentalListing, RentalListingCreation, RentalListingPeriod } from "@dcl/schemas"
 import { ContractRentalListing } from "../../logic/rentals/types"
-import { DBInsertedRentalListing, DBGetRentalListing, DBInsertedRentaListingPeriods } from "../../ports/rentals"
+import { DBInsertedRentalListing, DBGetRentalListing, DBInsertedRentalListingPeriods } from "../../ports/rentals"
 import { fromMillisecondsToSeconds } from "./time"
 
 export function fromDBInsertedRentalListingToRental(DBRental: DBInsertedRentalListing): RentalListing {
@@ -36,7 +36,7 @@ function parseDBPeriodText(DBPeriodText: string): RentalListingPeriod {
   }
 }
 
-export function fromDBPeriodToPeriod(DBPeriod: DBInsertedRentaListingPeriods): RentalListingPeriod {
+export function fromDBPeriodToPeriod(DBPeriod: DBInsertedRentalListingPeriods): RentalListingPeriod {
   const { row } = DBPeriod
   const { maxDays, minDays, pricePerDay } = parseDBPeriodText(row)
   return {

--- a/src/controllers/handlers/rentals-handlers.ts
+++ b/src/controllers/handlers/rentals-handlers.ts
@@ -8,7 +8,12 @@ import {
 } from "@dcl/schemas"
 import * as authorizationMiddleware from "decentraland-crypto-middleware"
 import { fromDBGetRentalsListingsToRentalListings, fromDBInsertedRentalListingToRental } from "../../adapters/rentals"
-import { getPaginationParams, getTypedStringQueryParameter, InvalidParameterError } from "../../logic/http"
+import {
+  getPaginationParams,
+  getTypedArrayStringQueryParameter,
+  getTypedStringQueryParameter,
+  InvalidParameterError,
+} from "../../logic/http"
 import {
   InvalidSignature,
   NFTNotFound,
@@ -35,21 +40,27 @@ export async function getRentalsListingsHandler(
       url.searchParams,
       "sortDirection"
     )
-    const filterBy: RentalsListingsFilterBy = {
+    const filterBy: RentalsListingsFilterBy & { status?: RentalStatus[] } = {
       category:
         getTypedStringQueryParameter(Object.values(RentalsListingsFilterByCategory), url.searchParams, "category") ??
         undefined,
       text: url.searchParams.get("text") ?? undefined,
       lessor: url.searchParams.get("lessor") ?? undefined,
       tenant: url.searchParams.get("tenant") ?? undefined,
-      status: getTypedStringQueryParameter(Object.values(RentalStatus), url.searchParams, "status") ?? undefined,
+      status: getTypedArrayStringQueryParameter(Object.values(RentalStatus), url.searchParams, "status"),
       tokenId: url.searchParams.get("tokenId") ?? undefined,
       contractAddresses: url.searchParams.getAll("contractAddresses"),
       nftIds: url.searchParams.getAll("nftIds"),
       network:
         (getTypedStringQueryParameter(Object.values(Network), url.searchParams, "network") as Network) ?? undefined,
     }
-    const rentalListings = await rentals.getRentalsListings({ sortBy, sortDirection, page, limit, filterBy })
+    const rentalListings = await rentals.getRentalsListings({
+      sortBy,
+      sortDirection,
+      page,
+      limit,
+      filterBy,
+    })
     return {
       status: StatusCode.OK,
       body: {

--- a/src/logic/http/queryParameters.ts
+++ b/src/logic/http/queryParameters.ts
@@ -20,3 +20,14 @@ export function getTypedStringQueryParameter<T>(
   const parameterValue = queryParameters.get(parameterName) as T | null
   return getParameter(values, parameterName, parameterValue)
 }
+
+export function getTypedArrayStringQueryParameter<T extends string>(
+  values: T[],
+  queryParameters: URLSearchParams,
+  parameterName: string
+): T[] {
+  return queryParameters
+    .getAll(parameterName)
+    .map((parameterValue) => getParameter(values, parameterName, parameterValue as T))
+    .filter(Boolean) as T[]
+}

--- a/src/migrations/1666200974062_update-rental-statuses.ts
+++ b/src/migrations/1666200974062_update-rental-statuses.ts
@@ -1,0 +1,35 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { MigrationBuilder, ColumnDefinitions } from "node-pg-migrate"
+
+export const shorthands: ColumnDefinitions | undefined = undefined
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.addTypeValue("status", "claimed")
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  // Rename current status enum to old_status
+  pgm.renameType("status", "old_status")
+  // Create new enum with a temporal name
+  pgm.addType("status_new", ["open", "executed", "cancelled"])
+  // Update DB to remove the value we want to remove
+  pgm.sql("UPDATE rentals SET status = 'executed' WHERE status = 'claimed'")
+  // Drop the index based on the status column to prevent issues with the migration
+  pgm.dropIndex("rentals", ["token_id", "contract_address", "status"], { unique: true })
+  // Change the status column to the new type and drop the default to prevent casting issues
+  pgm.alterColumn("rentals", "status", {
+    type: "status_new",
+    using: "status::text::status_new",
+    default: null,
+  })
+  // Re-add the default value
+  pgm.alterColumn("rentals", "status", {
+    default: "open",
+  })
+  // Rename the new enum to its corresponding name
+  pgm.renameType("status_new", "status")
+  // Remove old enum
+  pgm.dropType("old_status")
+  // Re-create the index
+  pgm.createIndex("rentals", ["token_id", "contract_address", "status"], { where: "status = 'open'", unique: true })
+}

--- a/src/ports/rentals/component.ts
+++ b/src/ports/rentals/component.ts
@@ -24,14 +24,13 @@ import {
   DBRentalListing,
   NFT,
   DBRental,
-  DBPeriods,
   DBInsertedRentalListing,
   DBGetRentalListing,
   IndexerRental,
   DBMetadata,
   UpdateType,
   IndexerIndexSignerUpdate,
-  DBInsertedRentaListingPeriods,
+  DBInsertedRentalListingPeriods,
   IndexerIndexAssetUpdate,
   IndexerIndexContractUpdate,
   IndexerIndexesHistoryUpdate,
@@ -136,13 +135,6 @@ export async function createRentalsComponent(
     return queryResult.rentals
   }
 
-  type IndexUpdateQueryParameters<T> = {
-    filterBy?: Partial<T>
-    first: number
-    orderBy?: keyof T
-    orderDirection?: "desc" | "asc"
-  }
-
   async function getIndexUpdatesFromIndexer(options: {
     filterBy?: { signer: string; contractAddress: string }
     first: number
@@ -161,7 +153,7 @@ export async function createRentalsComponent(
       orderDirection
     )
 
-    const { querySignature: contractUpdateSignture } = buildQueryParameters<IndexerIndexesHistoryUpdateQuery>(
+    const { querySignature: contractUpdateSignature } = buildQueryParameters<IndexerIndexesHistoryUpdateQuery>(
       { contractAddress: filterBy?.contractAddress },
       first,
       orderBy,
@@ -169,7 +161,7 @@ export async function createRentalsComponent(
     )
 
     const query = `query IndexUpdates(${queryVariables}) {
-      contract: indexesUpdateContractHistories(${contractUpdateSignture}){
+      contract: indexesUpdateContractHistories(${contractUpdateSignature}){
         newIndex
       }
       signer: indexesUpdateSignerHistories(${querySignature}){
@@ -330,7 +322,7 @@ export async function createRentalsComponent(
       })
       insertPeriodsQuery.append(SQL` RETURNING (min_days::text, max_days::text, price_per_day, rental_id)`)
 
-      const createdPeriods = await client.query<DBInsertedRentaListingPeriods>(insertPeriodsQuery)
+      const createdPeriods = await client.query<DBInsertedRentalListingPeriods>(insertPeriodsQuery)
       logger.debug(buildLogMessageForRental("Inserted periods"))
 
       await client.query(SQL`COMMIT`)
@@ -356,19 +348,32 @@ export async function createRentalsComponent(
     }
   }
 
-  async function getRentalsListings(params: {
-    sortBy: RentalsListingsSortBy | null
-    sortDirection: RentalsListingSortDirection | null
-    filterBy: RentalsListingsFilterBy | null
-    page: number
-    limit: number
-  }): Promise<DBGetRentalListing[]> {
+  async function getRentalsListings(
+    params: {
+      sortBy: RentalsListingsSortBy | null
+      sortDirection: RentalsListingSortDirection | null
+      filterBy: (RentalsListingsFilterBy & { status?: RentalStatus[] }) | null
+      page: number
+      limit: number
+    },
+    getHistoricData?: boolean
+  ): Promise<DBGetRentalListing[]> {
     const { sortBy, page, limit, filterBy, sortDirection } = params
     const sortByParam = sortBy ?? RentalsListingsSortBy.RENTAL_LISTING_DATE
     const sortDirectionParam = sortDirection ?? RentalsListingSortDirection.ASC
 
     const filterByCategory = filterBy?.category ? SQL`AND metadata.category = ${filterBy.category}\n` : ""
-    const filterByStatus = filterBy?.status ? SQL`AND rentals.status = ${filterBy.status}\n` : ""
+    let filterByStatus = SQL``
+    if (filterBy?.status && filterBy.status.length > 0) {
+      filterByStatus = SQL`AND (`
+      filterBy.status.forEach((status, index, array) => {
+        filterByStatus.append(`rentals.status = '${status}'`)
+        if (index < array.length - 1) {
+          filterByStatus.append(` OR `)
+        }
+      })
+      filterByStatus.append(`)\n`)
+    }
     const filterByLessor = filterBy?.lessor ? SQL`AND rentals_listings.lessor = ${filterBy.lessor}\n` : ""
     const filterByTenant = filterBy?.tenant ? SQL`AND rentals_listings.tenant = ${filterBy.tenant}\n` : ""
     const filterBySearchText = filterBy?.text
@@ -404,12 +409,16 @@ export async function createRentalsComponent(
 
     // The periods array items must be casted to string because the numeric arrays are considered as number by node-pg
     let query = SQL`SELECT rentals.*, metadata.category, metadata.search_text, metadata.created_at as metadata_created_at FROM metadata,
-      (SELECT rentals.*, rentals_listings.tenant, rentals_listings.lessor,
+      (SELECT `
+    if (!getHistoricData) {
+      query.append("DISTINCT ON (rentals.metadata_id) ")
+    }
+    query.append(`rentals.*, rentals_listings.tenant, rentals_listings.lessor,
       COUNT(*) OVER() as rentals_listings_count, array_agg(ARRAY[periods.min_days::text, periods.max_days::text, periods.price_per_day::text] ORDER BY periods.id) as periods,
       min(periods.price_per_day) as min_price_per_day, max(periods.price_per_day) as max_price_per_day
       FROM rentals, rentals_listings, periods WHERE  
       rentals.id = rentals_listings.id AND
-      periods.rental_id = rentals.id\n`
+      periods.rental_id = rentals.id\n`)
     query.append(filterByStatus)
     query.append(filterByTokenId)
     query.append(filterByContractAddress)
@@ -424,7 +433,6 @@ export async function createRentalsComponent(
     query.append(filterByCategory)
     query.append(filterBySearchText)
     query.append(sortByQuery)
-
     const results = await database.query<DBGetRentalListing>(query)
     return results.rows
   }
@@ -490,7 +498,7 @@ export async function createRentalsComponent(
       promisesOfUpdate.push(
         database.query(
           SQL`UPDATE rentals SET updated_at = ${new Date(indexerRentalLastUpdate)}, status = ${
-            RentalStatus.EXECUTED
+            indexerRentals[0].ownerHasClaimedAsset ? RentalStatus.CLAIMED : RentalStatus.EXECUTED
           }, started_at = ${new Date(fromSecondsToMilliseconds(Number(indexerRentals[0].startedAt)))} WHERE id = ${
             rentalData.id
           }`
@@ -685,8 +693,11 @@ export async function createRentalsComponent(
                   SQL`UPDATE rentals SET updated_at = ${new Date(
                     fromSecondsToMilliseconds(Number(rental.updatedAt))
                   )}, started_at = ${new Date(fromSecondsToMilliseconds(Number(rental.startedAt)))}, status = ${
-                    RentalStatus.EXECUTED
+                    rental.ownerHasClaimedAsset ? RentalStatus.CLAIMED : RentalStatus.EXECUTED
                   } WHERE id = ${dbRental.id}`
+                ),
+                client.query(
+                  SQL`UPDATE rentals SET status = ${RentalStatus.CLAIMED} WHERE contract_address = ${rental.contractAddress} AND token_id = ${rental.tokenId} AND status = ${RentalStatus.EXECUTED}`
                 ),
                 client.query(SQL`UPDATE rentals_listings SET tenant = ${rental.tenant} WHERE id = ${dbRental.id}`),
               ])

--- a/src/ports/rentals/types.ts
+++ b/src/ports/rentals/types.ts
@@ -12,7 +12,7 @@ import {
 export type IRentalsComponent = {
   createRentalListing(rental: RentalListingCreation, lessorAddress: string): Promise<DBInsertedRentalListing>
   refreshRentalListing(rentalId: string): Promise<DBGetRentalListing>
-  getRentalsListings(params: GetRentalListingParameters): Promise<DBGetRentalListing[]>
+  getRentalsListings(params: GetRentalListingParameters, getHistoricData?: boolean): Promise<DBGetRentalListing[]>
   cancelRentalsListings(): Promise<void>
   updateRentalsListings(): Promise<void>
   updateMetadata(): Promise<void>
@@ -23,7 +23,7 @@ export type GetRentalListingParameters = {
   sortDirection: RentalsListingSortDirection | null
   page: number
   limit: number
-  filterBy: RentalsListingsFilterBy | null
+  filterBy: (RentalsListingsFilterBy & { status?: RentalStatus[] }) | null
 }
 
 export enum UpdateType {
@@ -80,10 +80,10 @@ export type DBGetRentalListing = DBRental &
     metadata_id: string
   }
 
-export type DBInsertedRentaListingPeriods = { row: string }
+export type DBInsertedRentalListingPeriods = { row: string }
 
 export type DBInsertedRentalListing = DBRental &
-  DBRentalListing & { periods: DBInsertedRentaListingPeriods[] } & Pick<DBMetadata, "category" | "search_text">
+  DBRentalListing & { periods: DBInsertedRentalListingPeriods[] } & Pick<DBMetadata, "category" | "search_text">
 
 export type NFT = {
   /** The id of the NFT */

--- a/test/unit/rentals-handler.spec.ts
+++ b/test/unit/rentals-handler.spec.ts
@@ -141,12 +141,7 @@ describe("when creating a new rental listing", () => {
   })
 
   describe("and the listing creation fails with an invalid signature error", () => {
-    let contractAddress: string
-    let tokenId: string
-
     beforeEach(() => {
-      contractAddress = "0x1"
-      tokenId = "1"
       components = {
         rentals: createTestRentalsComponent({
           createRentalListing: jest.fn().mockRejectedValueOnce(new InvalidSignature()),
@@ -321,6 +316,62 @@ describe("when getting rental listings", () => {
 
     it("should propagate the error", () => {
       return expect(getRentalsListingsHandler({ components, url })).rejects.toThrowError(errorMessage)
+    })
+  })
+
+  describe("and the process was done with multiple statuses as filters", () => {
+    beforeEach(() => {
+      getRentalsListingsMock.mockResolvedValueOnce([])
+      url = new URL("http://localhost/v1/rental-listing?status=executed&status=open")
+    })
+
+    it("should get the rental listings according to the multiple statuses being asked for", async () => {
+      await expect(getRentalsListingsHandler({ components, url })).resolves.toEqual({
+        status: StatusCode.OK,
+        body: {
+          ok: true,
+          data: {
+            results: [],
+            total: 0,
+            page: 0,
+            pages: 0,
+            limit: 50,
+          },
+        },
+      })
+
+      expect(getRentalsListingsMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filterBy: expect.objectContaining({ status: [RentalStatus.EXECUTED, RentalStatus.OPEN] }),
+        })
+      )
+    })
+  })
+
+  describe("and the process was done with a single status as filter", () => {
+    beforeEach(() => {
+      getRentalsListingsMock.mockResolvedValueOnce([])
+      url = new URL("http://localhost/v1/rental-listing?status=executed")
+    })
+
+    it("should get the rental listings according to the single status being asked for", async () => {
+      await expect(getRentalsListingsHandler({ components, url })).resolves.toEqual({
+        status: StatusCode.OK,
+        body: {
+          ok: true,
+          data: {
+            results: [],
+            total: 0,
+            page: 0,
+            pages: 0,
+            limit: 50,
+          },
+        },
+      })
+
+      expect(getRentalsListingsMock).toHaveBeenCalledWith(
+        expect.objectContaining({ filterBy: expect.objectContaining({ status: [RentalStatus.EXECUTED] }) })
+      )
     })
   })
 


### PR DESCRIPTION
This PR does the following:
- Adds support for filtering by the claimed status
- Adds support for filtering by multiple statuses so we can later grab the opened and executed rentals to show them.
- Adds a new migration to support the new enumerated value.
- Modifies the rental update endpoint and job to set the rental statuses as claimed when an owner claims their LAND.