### PR TITLE
fix: Remove the date cast on the server to avoid timezone issues

### DIFF
--- a/src/adapters/rentals/rentals.ts
+++ b/src/adapters/rentals/rentals.ts
@@ -55,7 +55,7 @@ export function fromRentalCreationToContractRentalListing(
     signer: lessor,
     contractAddress: rental.contractAddress,
     tokenId: rental.tokenId,
-    expiration: fromMillisecondsToSeconds(new Date(rental.expiration).getTime()).toString(),
+    expiration: fromMillisecondsToSeconds(rental.expiration).toString(),
     indexes: rental.nonces,
     pricePerDay: rental.periods.map((period) => period.pricePerDay),
     maxDays: rental.periods.map((period) => period.maxDays.toString()),


### PR DESCRIPTION
Closes #156

## Disclaimer

I'm not sure this is the proper fix. I've analysed all the fields used by the UI to create the signature and they match with the ones the server uses. The only thing I think it might be affecting, its the `Date` object in the server adding a timezone, because it can be located in the different region than the UI.