### PR TITLE
fix: Don't run add-type-value migration inside a transaction

### DIFF
--- a/src/migrations/1666280846241_add-indexes-to-update-type.ts
+++ b/src/migrations/1666280846241_add-indexes-to-update-type.ts
@@ -3,6 +3,7 @@ import { MigrationBuilder, ColumnDefinitions } from "node-pg-migrate"
 export const shorthands: ColumnDefinitions | undefined = undefined
 
 export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.noTransaction()
   pgm.addTypeValue("update", "indexes")
 }
 

--- a/src/migrations/1666716265861_update-rental-status.ts
+++ b/src/migrations/1666716265861_update-rental-status.ts
@@ -4,6 +4,7 @@ import { MigrationBuilder, ColumnDefinitions } from "node-pg-migrate"
 export const shorthands: ColumnDefinitions | undefined = undefined
 
 export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.noTransaction()
   pgm.addTypeValue("status", "claimed", { ifNotExists: true })
 }
 


### PR DESCRIPTION
Running the `addTypeValue` migration inside of a transaction (ran by default by `node-pg-migrate`) resulted in:
```
2022-11-02 17:27:27 | ### MIGRATION 1666280846241_add-indexes-to-update-type (UP) ###
-- | --
  |   |   | 2022-11-02 17:27:27 | error: current transaction is aborted, commands ignored until end of transaction block
  |   |   | 2022-11-02 17:27:27 | select pg_advisory_unlock(7241865325823964) as "lockReleased"
  |   |   | 2022-11-02 17:27:27 | Error executing:
  |   |   | 2022-11-02 17:27:27 | error: ALTER TYPE ... ADD cannot run inside a transaction block
  |   |   | 2022-11-02 17:27:27 | ALTER TYPE "update" ADD VALUE $pga$indexes$pga$;
  |   |   | 2022-11-02 17:27:27 | Error executing:
  |   |   | 2022-11-02 17:27:27 | <<< Error initializing components. Stopping components and closing application. >>>
  |   |   | 2022-11-02 17:27:27 | error: ALTER TYPE ... ADD cannot run inside a transaction block
  |   |   | 2022-11-02 17:27:27 | <<< Error initializing component: "database". Error will appear in the next line >>>

```