### PR TITLE
fix: Enum type change

### DIFF
--- a/src/migrations/1666280846241_add-indexes-to-update-type.ts
+++ b/src/migrations/1666280846241_add-indexes-to-update-type.ts
@@ -3,25 +3,30 @@ import { MigrationBuilder, ColumnDefinitions } from "node-pg-migrate"
 export const shorthands: ColumnDefinitions | undefined = undefined
 
 export async function up(pgm: MigrationBuilder): Promise<void> {
-  pgm.noTransaction()
-  pgm.addTypeValue("update", "indexes")
+  pgm.renameType("update", "old_update")
+  pgm.createType("new_update", ["metadata", "rentals", "indexes"])
+  pgm.alterColumn("updates", "type", {
+    type: "new_update",
+    using: "type::text::new_update",
+  })
+  pgm.dropType("old_update")
+  pgm.renameType("new_update", "update")
 }
 
 export async function down(pgm: MigrationBuilder): Promise<void> {
   // Rename current status enum to old_status
   pgm.renameType("update", "old_update")
   // Create new enum with a temporal name
-  pgm.addType("update_new", ["metadata", "rentals"])
+  pgm.addType("new_update", ["metadata", "rentals"])
   // Update DB to remove the value we want to remove
   pgm.sql("DELETE FROM updates WHERE type = 'indexes'")
   // Change the status column to the new type and drop the default to prevent casting issues
   pgm.alterColumn("updates", "type", {
-    type: "update_new",
-    using: "type::text::update_new",
-    default: null,
+    type: "new_update",
+    using: "type::text::new_update",
   })
   // Rename the new enum to its corresponding name
-  pgm.renameType("update_new", "update")
+  pgm.renameType("new_update", "update")
   // Remove old enum
   pgm.dropType("old_update")
 }

--- a/src/migrations/1666716265861_update-rental-status.ts
+++ b/src/migrations/1666716265861_update-rental-status.ts
@@ -4,15 +4,24 @@ import { MigrationBuilder, ColumnDefinitions } from "node-pg-migrate"
 export const shorthands: ColumnDefinitions | undefined = undefined
 
 export async function up(pgm: MigrationBuilder): Promise<void> {
-  pgm.noTransaction()
-  pgm.addTypeValue("status", "claimed", { ifNotExists: true })
+  pgm.renameType("status", "old_status")
+  pgm.createType("new_status", ["open", "executed", "cancelled", "claimed"])
+  pgm.dropIndex("rentals", ["token_id", "contract_address", "status"], { unique: true })
+  pgm.alterColumn("rentals", "status", {
+    type: "new_status",
+    using: "status::text::new_status",
+    default: null,
+  })
+  pgm.dropType("old_status")
+  pgm.renameType("new_status", "status")
+  pgm.createIndex("rentals", ["token_id", "contract_address", "status"], { where: "status = 'open'", unique: true })
 }
 
 export async function down(pgm: MigrationBuilder): Promise<void> {
   // Rename current status enum to old_status
   pgm.renameType("status", "old_status")
   // Create new enum with a temporal name
-  pgm.addType("status_new", ["open", "executed", "cancelled"])
+  pgm.addType("new_status", ["open", "executed", "cancelled"])
   // Update DB to remove the value we want to remove
   pgm.sql("UPDATE rentals SET status = 'executed' WHERE status = 'claimed'")
   // Drop the index based on the status column to prevent issues with the migration
@@ -20,7 +29,7 @@ export async function down(pgm: MigrationBuilder): Promise<void> {
   // Change the status column to the new type and drop the default to prevent casting issues
   pgm.alterColumn("rentals", "status", {
     type: "status_new",
-    using: "status::text::status_new",
+    using: "status::text::new_status",
     default: null,
   })
   // Re-add the default value
@@ -28,7 +37,7 @@ export async function down(pgm: MigrationBuilder): Promise<void> {
     default: "open",
   })
   // Rename the new enum to its corresponding name
-  pgm.renameType("status_new", "status")
+  pgm.renameType("new_status", "status")
   // Remove old enum
   pgm.dropType("old_status")
   // Re-create the index


### PR DESCRIPTION
This PR changes the way the migrations are ran, removing the `addTypeValue` method that required the query to be done outside a transaction.