### PR TITLE
fix: Offset parameter & total

### DIFF
--- a/src/controllers/handlers/rentals-handlers.ts
+++ b/src/controllers/handlers/rentals-handlers.ts
@@ -32,7 +32,7 @@ export async function getRentalsListingsHandler(
     components: { rentals },
   } = context
 
-  const { page, limit } = getPaginationParams(url.searchParams)
+  const { limit, offset } = getPaginationParams(url.searchParams)
   try {
     const sortBy = getTypedStringQueryParameter(Object.values(RentalsListingsSortBy), url.searchParams, "sortBy")
     const sortDirection = getTypedStringQueryParameter(
@@ -59,12 +59,13 @@ export async function getRentalsListingsHandler(
       {
         sortBy,
         sortDirection,
-        page,
+        offset,
         limit,
         filterBy,
       },
       getHistoricData
     )
+
     return {
       status: StatusCode.OK,
       body: {
@@ -72,7 +73,7 @@ export async function getRentalsListingsHandler(
         data: {
           results: fromDBGetRentalsListingsToRentalListings(rentalListings),
           total: rentalListings.length > 0 ? Number(rentalListings[0].rentals_listings_count) : 0,
-          page,
+          page: Math.floor(offset / limit),
           pages: rentalListings.length > 0 ? Math.ceil(Number(rentalListings[0].rentals_listings_count) / limit) : 0,
           limit,
         },

--- a/src/logic/http/pagination.ts
+++ b/src/logic/http/pagination.ts
@@ -1,13 +1,22 @@
 const MAX_LIMIT = 50
 const DEFAULT_PAGE = 0
 
-export const getPaginationParams = (params: URLSearchParams): { limit: number; page: number } => {
+export const getPaginationParams = (params: URLSearchParams): { limit: number; offset: number } => {
   const limit = params.get("limit")
+  const offset = params.get("offset")
   const page = params.get("page")
   const parsedLimit = parseInt(limit as string, 10)
   const parsedPage = parseInt(page as string, 10)
+  const parsedOffset = parseInt(offset as string, 10)
+
+  const paginationLimit =
+    limit && !isNaN(parsedLimit) && parsedLimit <= MAX_LIMIT && parsedLimit > 0 ? parsedLimit : MAX_LIMIT
+  const paginationOffset = isNaN(parsedOffset)
+    ? (page && !isNaN(parsedPage) && parsedPage >= 0 ? parsedPage : DEFAULT_PAGE) * paginationLimit
+    : parsedOffset
+
   return {
-    limit: limit && !isNaN(parsedLimit) && parsedLimit <= MAX_LIMIT && parsedLimit > 0 ? parsedLimit : MAX_LIMIT,
-    page: page && !isNaN(parsedPage) && parsedPage >= 0 ? parsedPage : DEFAULT_PAGE,
+    limit: paginationLimit,
+    offset: paginationOffset,
   }
 }

--- a/src/ports/rentals/types.ts
+++ b/src/ports/rentals/types.ts
@@ -21,7 +21,7 @@ export type IRentalsComponent = {
 export type GetRentalListingParameters = {
   sortBy: RentalsListingsSortBy | null
   sortDirection: RentalsListingSortDirection | null
-  page: number
+  offset: number
   limit: number
   filterBy: (RentalsListingsFilterBy & { status?: RentalStatus[] }) | null
 }

--- a/test/unit/http-logic.spec.ts
+++ b/test/unit/http-logic.spec.ts
@@ -12,7 +12,7 @@ describe("when getting the pagination params", () => {
     it("should return the default limit", () => {
       expect(getPaginationParams(new URLSearchParams({ limit: "200" }))).toEqual({
         limit: 50,
-        page: 0,
+        offset: 0,
       })
     })
   })
@@ -21,7 +21,7 @@ describe("when getting the pagination params", () => {
     it("should return the default limit", () => {
       expect(getPaginationParams(new URLSearchParams({ limit: "-100" }))).toEqual({
         limit: 50,
-        page: 0,
+        offset: 0,
       })
     })
   })
@@ -30,7 +30,7 @@ describe("when getting the pagination params", () => {
     it("should return the default limit", () => {
       expect(getPaginationParams(new URLSearchParams({ limit: "notAnInteger" }))).toEqual({
         limit: 50,
-        page: 0,
+        offset: 0,
       })
     })
   })
@@ -39,7 +39,7 @@ describe("when getting the pagination params", () => {
     it("should return the value as the limit", () => {
       expect(getPaginationParams(new URLSearchParams({ limit: "10" }))).toEqual({
         limit: 10,
-        page: 0,
+        offset: 0,
       })
     })
   })
@@ -48,25 +48,25 @@ describe("when getting the pagination params", () => {
     it("should return the default page", () => {
       expect(getPaginationParams(new URLSearchParams({}))).toEqual({
         limit: 50,
-        page: 0,
+        offset: 0,
       })
     })
   })
 
   describe("and the page is set to a a value that can't be parsed as a number", () => {
-    it("should return the default page", () => {
+    it("should return the default offset", () => {
       expect(getPaginationParams(new URLSearchParams({ page: "notAnInteger" }))).toEqual({
         limit: 50,
-        page: 0,
+        offset: 0,
       })
     })
   })
 
   describe("and the page is set to a negative integer", () => {
-    it("should return the default page", () => {
+    it("should return the default offset", () => {
       expect(getPaginationParams(new URLSearchParams({ page: "-20" }))).toEqual({
         limit: 50,
-        page: 0,
+        offset: 0,
       })
     })
   })
@@ -75,7 +75,7 @@ describe("when getting the pagination params", () => {
     it("should return the value as the page", () => {
       expect(getPaginationParams(new URLSearchParams({ page: "1" }))).toEqual({
         limit: 50,
-        page: 1,
+        offset: 50,
       })
     })
   })

--- a/test/unit/rentals-component.spec.ts
+++ b/test/unit/rentals-component.spec.ts
@@ -425,7 +425,7 @@ describe("when getting rental listings", () => {
     it("should propagate the error", () => {
       expect(
         rentalsComponent.getRentalsListings({
-          page: 0,
+          offset: 0,
           limit: 10,
           sortBy: null,
           sortDirection: null,
@@ -444,7 +444,7 @@ describe("when getting rental listings", () => {
     it("should have made the query to get the listings with the category condition", async () => {
       await expect(
         rentalsComponent.getRentalsListings({
-          page: 0,
+          offset: 0,
           limit: 10,
           sortBy: null,
           sortDirection: null,
@@ -453,8 +453,8 @@ describe("when getting rental listings", () => {
           },
         })
       ).resolves.toEqual(dbGetRentalListings)
-      expect(dbQueryMock.mock.calls[0][0].text).toEqual(expect.stringContaining("AND metadata.category = $3"))
-      expect(dbQueryMock.mock.calls[0][0].values).toEqual([10, 0, "parcel"])
+      expect(dbQueryMock.mock.calls[0][0].text).toEqual(expect.stringContaining("AND metadata.category = $1"))
+      expect(dbQueryMock.mock.calls[0][0].values).toEqual(["parcel", 10, 0])
     })
   })
 
@@ -468,7 +468,7 @@ describe("when getting rental listings", () => {
       it("should have made the query to get the listings with the status condition", async () => {
         await expect(
           rentalsComponent.getRentalsListings({
-            page: 0,
+            offset: 0,
             limit: 10,
             sortBy: null,
             sortDirection: null,
@@ -487,7 +487,7 @@ describe("when getting rental listings", () => {
       it("should have made the query to get the listings with the multiple statuses condition", async () => {
         await expect(
           rentalsComponent.getRentalsListings({
-            page: 0,
+            offset: 0,
             limit: 10,
             sortBy: null,
             sortDirection: null,
@@ -514,7 +514,7 @@ describe("when getting rental listings", () => {
     it("should have made the query to get the listings with the lessor condition", async () => {
       await expect(
         rentalsComponent.getRentalsListings({
-          page: 0,
+          offset: 0,
           limit: 10,
           sortBy: null,
           sortDirection: null,
@@ -538,7 +538,7 @@ describe("when getting rental listings", () => {
     it("should have made the query to get the listings with the tenant condition", async () => {
       await expect(
         rentalsComponent.getRentalsListings({
-          page: 0,
+          offset: 0,
           limit: 10,
           sortBy: null,
           sortDirection: null,
@@ -562,7 +562,7 @@ describe("when getting rental listings", () => {
     it("should have made the query to get the listings with the text condition", async () => {
       await expect(
         rentalsComponent.getRentalsListings({
-          page: 0,
+          offset: 0,
           limit: 10,
           sortBy: null,
           sortDirection: null,
@@ -575,7 +575,8 @@ describe("when getting rental listings", () => {
       expect(dbQueryMock.mock.calls[0][0].text).toEqual(
         expect.stringContaining("AND metadata.search_text ILIKE '%' || ")
       )
-      expect(dbQueryMock.mock.calls[0][0].values).toEqual([10, 0, "someText"])
+      console.log(dbQueryMock.mock.calls[0][0].values)
+      expect(dbQueryMock.mock.calls[0][0].values).toEqual(["someText", 10, 0])
     })
   })
 
@@ -588,7 +589,7 @@ describe("when getting rental listings", () => {
     it("should have made the query to get the listings with the tokenId condition", async () => {
       await expect(
         rentalsComponent.getRentalsListings({
-          page: 0,
+          offset: 0,
           limit: 10,
           sortBy: null,
           sortDirection: null,
@@ -622,7 +623,7 @@ describe("when getting rental listings", () => {
       it("should not have made the query to get the listings with the contract addresses condition", async () => {
         await expect(
           rentalsComponent.getRentalsListings({
-            page: 0,
+            offset: 0,
             limit: 10,
             sortBy: null,
             sortDirection: null,
@@ -648,7 +649,7 @@ describe("when getting rental listings", () => {
       it("should have made the query to get the listings with the contract addresses condition", async () => {
         await expect(
           rentalsComponent.getRentalsListings({
-            page: 0,
+            offset: 0,
             limit: 10,
             sortBy: null,
             sortDirection: null,
@@ -677,7 +678,7 @@ describe("when getting rental listings", () => {
     it("should have made the query to get the listings with the network condition", async () => {
       await expect(
         rentalsComponent.getRentalsListings({
-          page: 0,
+          offset: 0,
           limit: 10,
           sortBy: null,
           sortDirection: null,
@@ -705,7 +706,7 @@ describe("when getting rental listings", () => {
     it("should not include any filters in the query", async () => {
       await expect(
         rentalsComponent.getRentalsListings({
-          page: 0,
+          offset: 0,
           limit: 10,
           sortBy: null,
           sortDirection: null,
@@ -730,7 +731,7 @@ describe("when getting rental listings", () => {
     it("should include the default order and order direction in the query", async () => {
       await expect(
         rentalsComponent.getRentalsListings({
-          page: 0,
+          offset: 0,
           limit: 10,
           sortBy: null,
           sortDirection: null,
@@ -751,7 +752,7 @@ describe("when getting rental listings", () => {
     it("should include the default order and the specified order direction in the query", async () => {
       await expect(
         rentalsComponent.getRentalsListings({
-          page: 0,
+          offset: 0,
           limit: 10,
           sortBy: null,
           sortDirection: RentalsListingSortDirection.DESC,
@@ -772,7 +773,7 @@ describe("when getting rental listings", () => {
     it("should include the search by text order in the query", async () => {
       await expect(
         rentalsComponent.getRentalsListings({
-          page: 0,
+          offset: 0,
           limit: 10,
           sortBy: RentalsListingsSortBy.NAME,
           sortDirection: null,
@@ -793,7 +794,7 @@ describe("when getting rental listings", () => {
     it("should include the created_at order in the query", async () => {
       await expect(
         rentalsComponent.getRentalsListings({
-          page: 0,
+          offset: 0,
           limit: 10,
           sortBy: RentalsListingsSortBy.RENTAL_LISTING_DATE,
           sortDirection: null,
@@ -814,7 +815,7 @@ describe("when getting rental listings", () => {
     it("should include the max_price_per_day order in the query", async () => {
       await expect(
         rentalsComponent.getRentalsListings({
-          page: 0,
+          offset: 0,
           limit: 10,
           sortBy: RentalsListingsSortBy.MAX_RENTAL_PRICE,
           sortDirection: null,
@@ -837,7 +838,7 @@ describe("when getting rental listings", () => {
     it("should include the min_price_per_day order in the query", async () => {
       await expect(
         rentalsComponent.getRentalsListings({
-          page: 0,
+          offset: 0,
           limit: 10,
           sortBy: RentalsListingsSortBy.MIN_RENTAL_PRICE,
           sortDirection: null,


### PR DESCRIPTION
This PR fixes two issues:
1. The total returned by the signature server when requesting the listings was off, it was not returning the actual total of entries.
2. The page parameter was not computed properly into an offset, so it was acting as an offset and retrieving a wrong list of rental listings.

To fix 1, the total was moved from the inside select into the outside select, changing the amount of rental listings that are going to be returned to the real result.
To fix 2, the page parameter is now computed as an offset, having now the correct number of the offset for any given page. The offset query parameter is now added to replicate the `skip` parameter often used in the `nft-server`, making it easier to perform the requests against the service.