### PR TITLE
fix: Signatures with V 0 or 1

### DIFF
--- a/src/logic/rentals/ethereum.ts
+++ b/src/logic/rentals/ethereum.ts
@@ -2,6 +2,7 @@ import { ethers } from "ethers"
 import { ChainId } from "@dcl/schemas"
 import { _TypedDataEncoder } from "@ethersproject/hash"
 import { ContractData, ContractName, getContract } from "decentraland-transactions"
+import { hasECDSASignatureAValidV } from "../../ports/rentals/utils"
 import { ContractRentalListing, RentalListingSignatureData } from "./types"
 
 async function buildRentalListingSignatureData(
@@ -52,5 +53,6 @@ export async function verifyRentalsListingSignature(
     rentalListingSignatureData.signature
   )
 
-  return signingAddress.toLowerCase() === rentalListingSignatureData.values.signer
+  const isVValid = hasECDSASignatureAValidV(rentalListing.signature)
+  return signingAddress.toLowerCase() === rentalListingSignatureData.values.signer && isVValid
 }

--- a/src/ports/rentals/component.ts
+++ b/src/ports/rentals/component.ts
@@ -38,7 +38,7 @@ import {
   IndexUpdateEventType,
 } from "./types"
 import { buildQueryParameters } from "./graph"
-import { generateECDSASignatureWithInvalidV, generateECDSASignatureWithValidV } from "./utils"
+import { generateECDSASignatureWithInvalidV, generateECDSASignatureWithValidV, hasECDSASignatureAValidV } from "./utils"
 
 export async function createRentalsComponent(
   components: Pick<AppComponents, "database" | "logs" | "marketplaceSubgraph" | "rentalsSubgraph" | "config">
@@ -252,6 +252,10 @@ export async function createRentalsComponent(
       rental.chainId
     )
     if (!isSignatureValid) {
+      if (!hasECDSASignatureAValidV(rental.signature)) {
+        logger.error(buildLogMessageForRental("Invalid signature: ECDSA signature with V as 0 or 1"))
+        throw new InvalidSignature("The server does not accept ECDSA signatures with V as 0 or 1")
+      }
       logger.error(buildLogMessageForRental("Invalid signature"))
       throw new InvalidSignature()
     }

--- a/src/ports/rentals/component.ts
+++ b/src/ports/rentals/component.ts
@@ -548,6 +548,16 @@ export async function createRentalsComponent(
           SQL`UPDATE rentals_listings SET tenant = ${indexerRentals[0].tenant} WHERE id = ${rentalData.id}`
         )
       )
+    } else if (
+      indexerRentalLastUpdate === 0 &&
+      rentalData.status === RentalStatus.OPEN &&
+      !hasECDSASignatureAValidV(rentalData.signature)
+    ) {
+      logger.info(`[Refresh][Update rental signature][${rentalId}]`)
+      // If the rental has not been executed and the signature is invalid, change it.
+      promisesOfUpdate.push(
+        database.query(SQL`UPDATE rentals SET signature = ${signature} WHERE id = ${rentalData.id}`)
+      )
     }
 
     // Identify if there's any blockchain nonce update

--- a/src/ports/rentals/component.ts
+++ b/src/ports/rentals/component.ts
@@ -38,6 +38,7 @@ import {
   IndexUpdateEventType,
 } from "./types"
 import { buildQueryParameters } from "./graph"
+import { generateECDSASignatureWithInvalidV, generateECDSASignatureWithValidV } from "./utils"
 
 export async function createRentalsComponent(
   components: Pick<AppComponents, "database" | "logs" | "marketplaceSubgraph" | "rentalsSubgraph" | "config">
@@ -251,6 +252,7 @@ export async function createRentalsComponent(
       rental.chainId
     )
     if (!isSignatureValid) {
+      logger.error(buildLogMessageForRental("Invalid signature"))
       throw new InvalidSignature()
     }
 
@@ -482,8 +484,9 @@ export async function createRentalsComponent(
     }
 
     const rentalData = rentalQueryResult.rows[0]
+    const signature = generateECDSASignatureWithValidV(rentalData.signature)
     const [indexerRentals, [indexerNFT], indexerIndexesUpdate] = await Promise.all([
-      getRentalsFromIndexer({ first: 1, filterBy: { signature: rentalData.signature } }),
+      getRentalsFromIndexer({ first: 1, filterBy: { signature } }),
       getNFTsFromIndexer({
         filterBy: { contractAddress: rentalData.contract_address, tokenId: rentalData.token_id },
         first: 1,
@@ -517,7 +520,7 @@ export async function createRentalsComponent(
         )
       )
 
-      // If the nft has been transfered, but not due to a rent starting
+      // If the nft has been transferred, but not due to a rent starting
       // Cancel the rental listing that now has a different owner
       if (rentalData.status === RentalStatus.OPEN && indexerNFT.owner.address !== rentalData.lessor) {
         database.query(SQL`UPDATE rentals SET status = ${RentalStatus.CANCELLED} WHERE id = ${rentalData.id}`)
@@ -533,9 +536,9 @@ export async function createRentalsComponent(
             indexerRentals[0].ownerHasClaimedAsset ? RentalStatus.CLAIMED : RentalStatus.EXECUTED
           }, rented_days = ${indexerRentals[0].rentalDays}, period_chosen = ${
             rentalData.period_id
-          }, started_at = ${new Date(fromSecondsToMilliseconds(Number(indexerRentals[0].startedAt)))} WHERE id = ${
-            rentalData.id
-          }`
+          }, started_at = ${new Date(
+            fromSecondsToMilliseconds(Number(indexerRentals[0].startedAt))
+          )}, signature = ${signature} WHERE id = ${rentalData.id}`
         ),
         database.query(
           SQL`UPDATE rentals_listings SET tenant = ${indexerRentals[0].tenant} WHERE id = ${rentalData.id}`
@@ -724,7 +727,11 @@ export async function createRentalsComponent(
               SQL`
                 SELECT rentals.id, lessor, status, started_at, periods.id period_id, periods.max_days, periods.min_days 
                 FROM rentals, rentals_listings, periods
-                WHERE rentals.id = rentals_listings.id AND rentals.signature = ${rental.signature} AND periods.rental_id = rentals.id
+                WHERE rentals.id = rentals_listings.id AND rentals.signature = ${
+                  rental.signature
+                } OR rentals.signature = ${generateECDSASignatureWithInvalidV(
+                rental.signature
+              )} AND periods.rental_id = rentals.id
               `
             )
             logger.debug(
@@ -745,7 +752,7 @@ export async function createRentalsComponent(
                     dbRental.period_id
                   }, started_at = ${new Date(fromSecondsToMilliseconds(Number(rental.startedAt)))}, status = ${
                     rental.ownerHasClaimedAsset ? RentalStatus.CLAIMED : RentalStatus.EXECUTED
-                  } WHERE id = ${dbRental.id}`
+                  }, signature = ${generateECDSASignatureWithValidV(rental.signature)} WHERE id = ${dbRental.id}`
                 ),
                 client.query(
                   SQL`UPDATE rentals SET status = ${RentalStatus.CLAIMED} WHERE contract_address = ${rental.contractAddress} AND token_id = ${rental.tokenId} AND status = ${RentalStatus.EXECUTED} AND started_at < ${dbRental.started_at}`

--- a/src/ports/rentals/errors.ts
+++ b/src/ports/rentals/errors.ts
@@ -23,7 +23,7 @@ export class RentalNotFound extends Error {
 }
 
 export class InvalidSignature extends Error {
-  constructor() {
-    super("The provided signature is invalid")
+  constructor(public reason?: string) {
+    super(`The provided signature is invalid ${reason ? `: ${reason}` : ""}`)
   }
 }

--- a/src/ports/rentals/errors.ts
+++ b/src/ports/rentals/errors.ts
@@ -24,6 +24,6 @@ export class RentalNotFound extends Error {
 
 export class InvalidSignature extends Error {
   constructor(public reason?: string) {
-    super(`The provided signature is invalid ${reason ? `: ${reason}` : ""}`)
+    super(`The provided signature is invalid${reason ? `: ${reason}` : ""}`)
   }
 }

--- a/src/ports/rentals/utils.ts
+++ b/src/ports/rentals/utils.ts
@@ -1,0 +1,50 @@
+/**
+ * Gets the last byte as a number from the a signature.
+ * @param signature - A ECDSA signature.
+ * @returns the last byte of the given signature.
+ */
+function getLastECDSASignatureByte(signature: string) {
+  return Number.parseInt(signature.slice(-2), 16)
+}
+
+/**
+ * Checks wether a ECDSA signature has a valid V.
+ * @param signature - A ECDSA signature.
+ * @throws "Invalid signature length" if the given signature has less than 65 bytes.
+ * @returns true if the v value is decimal 27 or 28 else otherwise.
+ */
+export function hasECDSASignatureAValidV(signature: string): boolean {
+  if (signature.length !== 130) {
+    return true
+  }
+
+  const lastSignatureByte = getLastECDSASignatureByte(signature)
+  return lastSignatureByte === 27 || lastSignatureByte === 28
+}
+
+/**
+ * Generates an ECDSA signature with a valid V from another signature by changing its V value to 27 or 28 if it was 0 or 1.
+ * @param signature - A ECDSA signature.
+ * @throws "Invalid signature length" if the given signature has less than 65 bytes.
+ * @returns a ECDSA signature based on the given one with its V value as 27 or 28.
+ */
+export function generateECDSASignatureWithValidV(signature: string): string {
+  const isSignatureVValid = hasECDSASignatureAValidV(signature)
+  return isSignatureVValid
+    ? signature
+    : signature.slice(0, -2) + (getLastECDSASignatureByte(signature) + 27).toString(16)
+}
+
+/**
+ * Generates an ECDSA signature with an invalid V from another signature by changing its V value to 0 or 1 if it was 27 or 28.
+ * This function will be used to maintain support of signatures with a V of 0 and 1.
+ * @param signature - A ECDSA signature.
+ * @throws "Invalid signature length" if the given signature has less than 65 bytes.
+ * @returns a ECDSA signature based on the given one with its V value as 27 or 28.
+ */
+export function generateECDSASignatureWithInvalidV(signature: string): string {
+  const isSignatureVValid = hasECDSASignatureAValidV(signature)
+  return isSignatureVValid
+    ? signature.slice(0, -2) + (getLastECDSASignatureByte(signature) - 27).toString(16)
+    : signature
+}

--- a/src/ports/rentals/utils.ts
+++ b/src/ports/rentals/utils.ts
@@ -14,10 +14,6 @@ function getLastECDSASignatureByte(signature: string) {
  * @returns true if the v value is decimal 27 or 28 else otherwise.
  */
 export function hasECDSASignatureAValidV(signature: string): boolean {
-  if (signature.length !== 130) {
-    return true
-  }
-
   const lastSignatureByte = getLastECDSASignatureByte(signature)
   return lastSignatureByte === 27 || lastSignatureByte === 28
 }

--- a/test/unit/rentals-component.spec.ts
+++ b/test/unit/rentals-component.spec.ts
@@ -1901,12 +1901,6 @@ describe("when updating the rental listings", () => {
           expect(dbClientReleaseMock).toHaveBeenCalled()
         })
       })
-
-      it("should have", () => {
-        expect(dbClientQueryMock).toHaveBeenCalledWith(
-          expect.objectContaining({ values: expect.arrayContaining(["falopa"]) })
-        )
-      })
     })
 
     describe("and the rentals to be updated don't exist in the database", () => {

--- a/test/unit/rentals-logic.spec.ts
+++ b/test/unit/rentals-logic.spec.ts
@@ -86,25 +86,27 @@ describe("when verifying the rentals listings signature", () => {
     })
   })
 
-  describe("and the signature is not expired and was signed by the provided address", () => {
+  describe("and the signature is not expired, it was signed by the provided address and its V is 28", () => {
     it("should return true", () => {
       return expect(verifyRentalsListingSignature(contractRentalListing, chainId)).resolves.toBe(true)
     })
   })
 
-  describe("and the signature has an invalid V", () => {
+  describe("and the signature has a V of 0 or 1", () => {
     beforeEach(() => {
-      contractRentalListing.signature = contractRentalListing.signature.slice(-2) + "00"
-    })
-
-    it("should return false", () => {
-      return expect(verifyRentalsListingSignature(contractRentalListing, chainId)).resolves.toBe(false)
-    })
-  })
-
-  describe("and the signature length is invalid", () => {
-    beforeEach(() => {
-      contractRentalListing.signature = "0x0000"
+      contractRentalListing = {
+        signer: "0x343889d9f2a54fc1c790880f8f8dc309ce7359d7",
+        contractAddress: "0x959e104e1a4db6317fa58f8295f586e1a978c297",
+        tokenId: "4364",
+        expiration: new Date("2023-02-28 00:00:00").getTime().toString(),
+        indexes: ["0", "0", "0"],
+        pricePerDay: ["8000000000000000000"],
+        maxDays: ["365"],
+        minDays: ["365"],
+        signature:
+          "0xb7cc6d9d616a6124cdb7dda758346499f5fe883e391bc3018c18eb4cd8f5b9957e1f4d82f5dfe3679262f983d0e587dcffe19c1647574dab439ac084f95570f401",
+        target: ethers.constants.AddressZero,
+      }
     })
 
     it("should return false", () => {

--- a/test/unit/rentals-logic.spec.ts
+++ b/test/unit/rentals-logic.spec.ts
@@ -91,4 +91,24 @@ describe("when verifying the rentals listings signature", () => {
       return expect(verifyRentalsListingSignature(contractRentalListing, chainId)).resolves.toBe(true)
     })
   })
+
+  describe("and the signature has an invalid V", () => {
+    beforeEach(() => {
+      contractRentalListing.signature = contractRentalListing.signature.slice(-2) + "00"
+    })
+
+    it("should return false", () => {
+      return expect(verifyRentalsListingSignature(contractRentalListing, chainId)).resolves.toBe(false)
+    })
+  })
+
+  describe("and the signature length is invalid", () => {
+    beforeEach(() => {
+      contractRentalListing.signature = "0x0000"
+    })
+
+    it("should return false", () => {
+      return expect(verifyRentalsListingSignature(contractRentalListing, chainId)).resolves.toBe(false)
+    })
+  })
 })

--- a/test/unit/rentals-utils.spec.ts
+++ b/test/unit/rentals-utils.spec.ts
@@ -1,0 +1,59 @@
+import { generateECDSASignatureWithValidV } from "../../src/ports/rentals/utils"
+
+describe("when generating an ECDSA signature with a valid V from a signature", () => {
+  describe("and the original signature has a valid V", () => {
+    it("should return the same signature", () => {
+      expect(
+        generateECDSASignatureWithValidV(
+          "0x402a10749ebca5d35af41b5780a2667e7edbc2ec64bad157714f533c69cb694c4e4595b88dce064a92772850e903c23d0f67625aeccf9308841ad34929daf51c"
+        )
+      ).toBe(
+        "0x402a10749ebca5d35af41b5780a2667e7edbc2ec64bad157714f533c69cb694c4e4595b88dce064a92772850e903c23d0f67625aeccf9308841ad34929daf51c"
+      )
+    })
+  })
+
+  describe("and the original signature is invalid and ending in 0", () => {
+    it("should return the original signature with its latest byte with the value 27", () => {
+      expect(
+        generateECDSASignatureWithValidV(
+          "0x402a10749ebca5d35af41b5780a2667e7edbc2ec64bad157714f533c69cb694c4e4595b88dce064a92772850e903c23d0f67625aeccf9308841ad34929daf500"
+        )
+      ).toBe(
+        "0x402a10749ebca5d35af41b5780a2667e7edbc2ec64bad157714f533c69cb694c4e4595b88dce064a92772850e903c23d0f67625aeccf9308841ad34929daf51b"
+      )
+    })
+  })
+
+  describe("and the original signature is invalid and ending in 1", () => {
+    it("should return the original signature with its latest byte with the value 28", () => {
+      expect(
+        generateECDSASignatureWithValidV(
+          "0x402a10749ebca5d35af41b5780a2667e7edbc2ec64bad157714f533c69cb694c4e4595b88dce064a92772850e903c23d0f67625aeccf9308841ad34929daf501"
+        )
+      ).toBe(
+        "0x402a10749ebca5d35af41b5780a2667e7edbc2ec64bad157714f533c69cb694c4e4595b88dce064a92772850e903c23d0f67625aeccf9308841ad34929daf51c"
+      )
+    })
+  })
+
+  describe("and the original signature has a length greater than 65 bytes", () => {
+    it("should return the same signature", () => {
+      expect(
+        generateECDSASignatureWithValidV(
+          "0x402a10749ebca5d35af41b5780a2667e7edbc2ec64bad157714f533c69cb694c4e4595b88dce064a92772850e903c23d0f67625aeccf9308841ad34929daf51ca"
+        )
+      ).toBe(
+        "0x402a10749ebca5d35af41b5780a2667e7edbc2ec64bad157714f533c69cb694c4e4595b88dce064a92772850e903c23d0f67625aeccf9308841ad34929daf51ca"
+      )
+    })
+  })
+
+  describe("and the original signature has a length lower than 65 bytes", () => {
+    it("should return the same signature", () => {
+      expect(generateECDSASignatureWithValidV("0x402a10749ebca5d35af41b5780a2667e")).toBe(
+        "0x402a10749ebca5d35af41b5780a2667e"
+      )
+    })
+  })
+})

--- a/test/unit/rentals-utils.spec.ts
+++ b/test/unit/rentals-utils.spec.ts
@@ -36,24 +36,4 @@ describe("when generating an ECDSA signature with a valid V from a signature", (
       )
     })
   })
-
-  describe("and the original signature has a length greater than 65 bytes", () => {
-    it("should return the same signature", () => {
-      expect(
-        generateECDSASignatureWithValidV(
-          "0x402a10749ebca5d35af41b5780a2667e7edbc2ec64bad157714f533c69cb694c4e4595b88dce064a92772850e903c23d0f67625aeccf9308841ad34929daf51ca"
-        )
-      ).toBe(
-        "0x402a10749ebca5d35af41b5780a2667e7edbc2ec64bad157714f533c69cb694c4e4595b88dce064a92772850e903c23d0f67625aeccf9308841ad34929daf51ca"
-      )
-    })
-  })
-
-  describe("and the original signature has a length lower than 65 bytes", () => {
-    it("should return the same signature", () => {
-      expect(generateECDSASignatureWithValidV("0x402a10749ebca5d35af41b5780a2667e")).toBe(
-        "0x402a10749ebca5d35af41b5780a2667e"
-      )
-    })
-  })
 })


### PR DESCRIPTION
This PR:
- Blocks signatures with a V 0 or 1 to be added to the signature server as part of a new rental listing.
- Adds support in the rentals job and the refresh endpoint to work with signatures with a V 0 or 1.