### PR TITLE
feat: Add target and updated after

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "template-server",
       "dependencies": {
-        "@dcl/schemas": "^5.29.0",
+        "@dcl/schemas": "^6.3.0",
         "@well-known-components/env-config-provider": "^1.1.1",
         "@well-known-components/http-server": "^1.1.6",
         "@well-known-components/interfaces": "^1.1.3",
@@ -662,9 +662,9 @@
       }
     },
     "node_modules/@dcl/schemas": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.29.0.tgz",
-      "integrity": "sha512-nLGFpIa3wRqlqoBuGpJGxgwsWMcKuTuphq6pf7PPjuv6ZyveUeaklKBl77VEfQvInAexMIqtljxsfA/ISZdkkw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-6.3.0.tgz",
+      "integrity": "sha512-Zhbly35/SZ5f4h0VnCtSjxxIaEbCpRzAo487Pd+PIuzx1vt5C9srJRHbMz0Cns6h3KiF8/E4Zsjl141NYIijzA==",
       "dependencies": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",
@@ -9624,9 +9624,9 @@
       }
     },
     "@dcl/schemas": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.29.0.tgz",
-      "integrity": "sha512-nLGFpIa3wRqlqoBuGpJGxgwsWMcKuTuphq6pf7PPjuv6ZyveUeaklKBl77VEfQvInAexMIqtljxsfA/ISZdkkw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-6.3.0.tgz",
+      "integrity": "sha512-Zhbly35/SZ5f4h0VnCtSjxxIaEbCpRzAo487Pd+PIuzx1vt5C9srJRHbMz0Cns6h3KiF8/E4Zsjl141NYIijzA==",
       "requires": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "semi": false
   },
   "dependencies": {
-    "@dcl/schemas": "^5.29.0",
+    "@dcl/schemas": "^6.3.0",
     "@well-known-components/env-config-provider": "^1.1.1",
     "@well-known-components/http-server": "^1.1.6",
     "@well-known-components/interfaces": "^1.1.3",

--- a/src/controllers/handlers/rentals-handlers.ts
+++ b/src/controllers/handlers/rentals-handlers.ts
@@ -42,7 +42,7 @@ export async function getRentalsListingsHandler(
       "sortDirection"
     )
     const getHistoricData = url.searchParams.get("history") === "true"
-    const filterBy: RentalsListingsFilterBy & { updatedAfter?: number; target: string } = {
+    const filterBy: RentalsListingsFilterBy = {
       category:
         getTypedStringQueryParameter(Object.values(RentalsListingsFilterByCategory), url.searchParams, "category") ??
         undefined,

--- a/src/controllers/handlers/rentals-handlers.ts
+++ b/src/controllers/handlers/rentals-handlers.ts
@@ -7,6 +7,7 @@ import {
   RentalStatus,
 } from "@dcl/schemas"
 import * as authorizationMiddleware from "decentraland-crypto-middleware"
+import { ethers } from "ethers"
 import { fromDBGetRentalsListingsToRentalListings, fromDBInsertedRentalListingToRental } from "../../adapters/rentals"
 import {
   getPaginationParams,
@@ -41,7 +42,7 @@ export async function getRentalsListingsHandler(
       "sortDirection"
     )
     const getHistoricData = url.searchParams.get("history") === "true"
-    const filterBy: RentalsListingsFilterBy & { status?: RentalStatus[] } = {
+    const filterBy: RentalsListingsFilterBy & { updatedAfter?: number; target: string } = {
       category:
         getTypedStringQueryParameter(Object.values(RentalsListingsFilterByCategory), url.searchParams, "category") ??
         undefined,
@@ -54,6 +55,8 @@ export async function getRentalsListingsHandler(
       nftIds: url.searchParams.getAll("nftIds"),
       network:
         (getTypedStringQueryParameter(Object.values(Network), url.searchParams, "network") as Network) ?? undefined,
+      updatedAfter: url.searchParams.get("updatedAfter") ? Number(url.searchParams.get("updatedAfter")) : undefined,
+      target: url.searchParams.get("target") ?? ethers.constants.AddressZero,
     }
     const rentalListings = await rentals.getRentalsListings(
       {

--- a/src/ports/rentals/component.ts
+++ b/src/ports/rentals/component.ts
@@ -370,9 +370,7 @@ export async function createRentalsComponent(
     params: {
       sortBy: RentalsListingsSortBy | null
       sortDirection: RentalsListingSortDirection | null
-      filterBy:
-        | (RentalsListingsFilterBy & { status?: RentalStatus[] } & { updatedAfter?: number; target?: string })
-        | null
+      filterBy: (RentalsListingsFilterBy & { status?: RentalStatus[] }) | null
       offset: number
       limit: number
     },

--- a/src/ports/rentals/component.ts
+++ b/src/ports/rentals/component.ts
@@ -370,7 +370,9 @@ export async function createRentalsComponent(
     params: {
       sortBy: RentalsListingsSortBy | null
       sortDirection: RentalsListingSortDirection | null
-      filterBy: (RentalsListingsFilterBy & { status?: RentalStatus[] }) | null
+      filterBy:
+        | (RentalsListingsFilterBy & { status?: RentalStatus[] } & { updatedAfter?: number; target?: string })
+        | null
       offset: number
       limit: number
     },
@@ -393,6 +395,10 @@ export async function createRentalsComponent(
       filterByStatus.append(`)\n`)
     }
     const filterByLessor = filterBy?.lessor ? SQL`AND rentals_listings.lessor = ${filterBy.lessor}\n` : ""
+    const filterByTarget = filterBy?.target ? SQL`AND rentals.target = ${filterBy.target}\n` : ""
+    const filterByUpdatedAfter = filterBy?.updatedAfter
+      ? SQL`AND rentals.updated_at > ${new Date(filterBy.updatedAfter)}\n`
+      : ""
     const filterByTenant = filterBy?.tenant ? SQL`AND rentals_listings.tenant = ${filterBy.tenant}\n` : ""
     const filterBySearchText = filterBy?.text
       ? SQL`AND metadata.search_text ILIKE '%' || ${filterBy.text} || '%'\n`
@@ -438,6 +444,8 @@ export async function createRentalsComponent(
       rentals.id = rentals_listings.id AND
       periods.rental_id = rentals.id\n`)
     query.append(filterByStatus)
+    query.append(filterByTarget)
+    query.append(filterByUpdatedAfter)
     query.append(filterByTokenId)
     query.append(filterByContractAddress)
     query.append(filterByNetwork)

--- a/src/ports/rentals/types.ts
+++ b/src/ports/rentals/types.ts
@@ -23,7 +23,7 @@ export type GetRentalListingParameters = {
   sortDirection: RentalsListingSortDirection | null
   offset: number
   limit: number
-  filterBy: (RentalsListingsFilterBy & { status?: RentalStatus[] }) | null
+  filterBy: (RentalsListingsFilterBy & { target?: string; updatedAfter?: number }) | null
 }
 
 export enum UpdateType {

--- a/src/ports/rentals/types.ts
+++ b/src/ports/rentals/types.ts
@@ -23,7 +23,7 @@ export type GetRentalListingParameters = {
   sortDirection: RentalsListingSortDirection | null
   offset: number
   limit: number
-  filterBy: (RentalsListingsFilterBy & { target?: string; updatedAfter?: number }) | null
+  filterBy: RentalsListingsFilterBy | null
 }
 
 export enum UpdateType {

--- a/test/unit/rentals-component.spec.ts
+++ b/test/unit/rentals-component.spec.ts
@@ -730,6 +730,8 @@ describe("when getting rental listings", () => {
       expect(dbQueryMock.mock.calls[0][0].text).not.toEqual(expect.stringContaining("AND rentals_listings.lessor = "))
       expect(dbQueryMock.mock.calls[0][0].text).not.toEqual(expect.stringContaining("AND rentals_listings.tenant = "))
       expect(dbQueryMock.mock.calls[0][0].text).not.toEqual(expect.stringContaining("AND rentals.status = "))
+      expect(dbQueryMock.mock.calls[0][0].text).not.toEqual(expect.stringContaining("AND rentals.target = "))
+      expect(dbQueryMock.mock.calls[0][0].text).not.toEqual(expect.stringContaining("AND rentals.updated_at > "))
       expect(dbQueryMock.mock.calls[0][0].text).not.toEqual(expect.stringContaining("AND rentals_listings.lessor = "))
       expect(dbQueryMock.mock.calls[0][0].text).not.toEqual(expect.stringContaining("AND metadata.search_text ILIKE %"))
     })
@@ -861,6 +863,62 @@ describe("when getting rental listings", () => {
 
       expect(dbQueryMock.mock.calls[0][0].text).toEqual(
         expect.stringContaining("ORDER BY rentals.min_price_per_day asc")
+      )
+    })
+  })
+
+  describe("and the target filter is set", () => {
+    beforeEach(() => {
+      dbGetRentalListings = []
+      dbQueryMock.mockResolvedValueOnce({ rows: dbGetRentalListings })
+    })
+
+    it("should have made the query to get the listings with the target condition", async () => {
+      await expect(
+        rentalsComponent.getRentalsListings({
+          offset: 0,
+          limit: 10,
+          sortBy: null,
+          sortDirection: null,
+          filterBy: {
+            target: "0x0",
+          },
+        })
+      ).resolves.toEqual(dbGetRentalListings)
+
+      expect(dbQueryMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          strings: expect.arrayContaining([expect.stringContaining("AND rentals.target = ")]),
+          values: ["0x0", 10, 0],
+        })
+      )
+    })
+  })
+
+  describe("and the updated after filter is set", () => {
+    beforeEach(() => {
+      dbGetRentalListings = []
+      dbQueryMock.mockResolvedValueOnce({ rows: dbGetRentalListings })
+    })
+
+    it("should have made the query to get the listings with the updated after", async () => {
+      await expect(
+        rentalsComponent.getRentalsListings({
+          offset: 0,
+          limit: 10,
+          sortBy: null,
+          sortDirection: null,
+          filterBy: {
+            updatedAfter: 1000000,
+          },
+        })
+      ).resolves.toEqual(dbGetRentalListings)
+
+      expect(dbQueryMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          strings: expect.arrayContaining([expect.stringContaining("AND rentals.updated_at > ")]),
+          values: [new Date(1000000), 10, 0],
+        })
       )
     })
   })

--- a/test/unit/rentals-handler.spec.ts
+++ b/test/unit/rentals-handler.spec.ts
@@ -575,6 +575,64 @@ describe("when getting rental listings", () => {
         },
       })
     })
+
+    describe("and the process is done with the target parameter set", () => {
+      const target = "0x1"
+      beforeEach(() => {
+        url = new URL(`http://localhost/v1/rental-listing?target=${target}`)
+      })
+
+      it("should have retrieved the rental listings with the given target", async () => {
+        await getRentalsListingsHandler({ components, url })
+        expect(getRentalsListingsMock).toHaveBeenCalledWith(
+          expect.objectContaining({ filterBy: expect.objectContaining({ target }) }),
+          false
+        )
+      })
+    })
+
+    describe("and the process is done with the target parameter unset", () => {
+      beforeEach(() => {
+        url = new URL(`http://localhost/v1/rental-listing`)
+      })
+
+      it("should have retrieved the rental listings with the zero address as the target", async () => {
+        await getRentalsListingsHandler({ components, url })
+        expect(getRentalsListingsMock).toHaveBeenCalledWith(
+          expect.objectContaining({ filterBy: expect.objectContaining({ target: ethers.constants.AddressZero }) }),
+          false
+        )
+      })
+    })
+
+    describe("and the process is done with the updatedAfter parameter set", () => {
+      const updatedAfter = Date.now()
+      beforeEach(() => {
+        url = new URL(`http://localhost/v1/rental-listing?updatedAfter=${updatedAfter}`)
+      })
+
+      it("should have retrieved the rental listings that were updated after the given timestamp", async () => {
+        await getRentalsListingsHandler({ components, url })
+        expect(getRentalsListingsMock).toHaveBeenCalledWith(
+          expect.objectContaining({ filterBy: expect.objectContaining({ updatedAfter }) }),
+          false
+        )
+      })
+    })
+
+    describe("and the process is done with the updatedAfter parameter unset", () => {
+      beforeEach(() => {
+        url = new URL(`http://localhost/v1/rental-listing`)
+      })
+
+      it("should have retrieved the rental listings without an updated after timestamp", async () => {
+        await getRentalsListingsHandler({ components, url })
+        expect(getRentalsListingsMock).toHaveBeenCalledWith(
+          expect.objectContaining({ filterBy: expect.not.objectContaining({ updatedAfter: expect.anything() }) }),
+          false
+        )
+      })
+    })
   })
 })
 


### PR DESCRIPTION
This PR adds the `target` and `updatedAfter` parameters to query rentals by target and by after an updated timestamp.