### PR TITLE
fix: Show a valid error on new rental listing with wrong chain id

### DIFF
--- a/src/controllers/handlers/rentals-handlers.ts
+++ b/src/controllers/handlers/rentals-handlers.ts
@@ -15,6 +15,7 @@ import {
   getTypedStringQueryParameter,
   InvalidParameterError,
 } from "../../logic/http"
+import { ContractNotFound } from "../../logic/rentals/errors"
 import {
   InvalidSignature,
   NFTNotFound,
@@ -173,6 +174,18 @@ export async function rentalsListingsCreationHandler(
         body: {
           ok: false,
           message: error.message,
+        },
+      }
+    } else if (error instanceof ContractNotFound) {
+      return {
+        status: StatusCode.BAD_REQUEST,
+        body: {
+          ok: false,
+          message: error.message,
+          data: {
+            contractName: error.contractName,
+            chainId: error.chainId,
+          },
         },
       }
     }

--- a/src/logic/rentals/errors.ts
+++ b/src/logic/rentals/errors.ts
@@ -1,0 +1,5 @@
+export class ContractNotFound extends Error {
+  constructor(public contractName: string, public chainId: number) {
+    super("The contract with the provided name and chain id was not found")
+  }
+}

--- a/src/logic/rentals/ethereum.ts
+++ b/src/logic/rentals/ethereum.ts
@@ -4,12 +4,18 @@ import { _TypedDataEncoder } from "@ethersproject/hash"
 import { ContractData, ContractName, getContract } from "decentraland-transactions"
 import { hasECDSASignatureAValidV } from "../../ports/rentals/utils"
 import { ContractRentalListing, RentalListingSignatureData } from "./types"
+import { ContractNotFound } from "./errors"
 
 async function buildRentalListingSignatureData(
   rentalListing: ContractRentalListing,
   chainId: ChainId
 ): Promise<RentalListingSignatureData> {
-  const rentalsContract: ContractData = getContract(ContractName.Rentals, chainId)
+  let rentalsContract: ContractData
+  try {
+    rentalsContract = getContract(ContractName.Rentals, chainId)
+  } catch (error) {
+    throw new ContractNotFound(ContractName.Rentals, chainId)
+  }
 
   const domain = {
     name: rentalsContract.name,

--- a/test/unit/rentals-logic.spec.ts
+++ b/test/unit/rentals-logic.spec.ts
@@ -3,6 +3,7 @@ import { ContractData, ContractName, getContract } from "decentraland-transactio
 import { ethers } from "ethers"
 import { TypedDataDomain, TypedDataField } from "@ethersproject/abstract-signer"
 import { ContractRentalListing, verifyRentalsListingSignature } from "../../src/logic/rentals"
+import { ContractNotFound } from "../../src/logic/rentals/errors"
 
 describe("when verifying the rentals listings signature", () => {
   let contractRentalListing: ContractRentalListing
@@ -60,6 +61,18 @@ describe("when verifying the rentals listings signature", () => {
       signature: await wallet._signTypedData(domain, types, values),
       target: ethers.constants.AddressZero,
     }
+  })
+
+  describe("and there's no contract with the given chain id", () => {
+    beforeEach(() => {
+      chainId = 3242342
+    })
+
+    it("should reject into a contract not found error", () => {
+      return expect(verifyRentalsListingSignature(contractRentalListing, chainId)).rejects.toThrow(
+        new ContractNotFound(ContractName.Rentals, chainId)
+      )
+    })
   })
 
   describe("and the signature was signed by a different address", () => {


### PR DESCRIPTION
When creating new rental listings it is possible to use any number as the chain id, making the request fail with a 500 and a generic error. To prevent this, this PR catches the exception of not finding a contract with the given chain id and responds accordingly.

Closes #190