### PR TITLE
fix: historic data logic rentals query

### DIFF
--- a/src/ports/rentals/queries.ts
+++ b/src/ports/rentals/queries.ts
@@ -157,7 +157,7 @@ export function getRentalListingsQuery(
   const { filterBy, sortBy, sortDirection, limit, offset } = params
 
   const rentalsQuery = SQL`(SELECT `
-  if (getHistoricData) {
+  if (!getHistoricData) {
     rentalsQuery.append(SQL`DISTINCT ON (rentals.metadata_id)`)
   }
 

--- a/src/ports/rentals/queries.ts
+++ b/src/ports/rentals/queries.ts
@@ -158,7 +158,7 @@ export function getRentalListingsQuery(
 
   const rentalsQuery = SQL`(SELECT `
   if (!getHistoricData) {
-    rentalsQuery.append(SQL`DISTINCT ON (rentals.metadata_id)`)
+    rentalsQuery.append(SQL`DISTINCT ON (rentals.metadata_id) `)
   }
 
   rentalsQuery.append(SQL`rentals.*,

--- a/test/unit/rentals-component.spec.ts
+++ b/test/unit/rentals-component.spec.ts
@@ -1224,6 +1224,58 @@ describe("when getting rental listings", () => {
       )
     }) 
   })
+
+  describe("and getHistoricData flag is on", () => {
+    beforeEach(() => {
+      dbGetRentalListings = []
+      dbQueryMock.mockResolvedValueOnce({ rows: dbGetRentalListings })
+    })
+
+    it("should only retrieve one rental for each nft (metadata_id)", async () => {
+      await expect(
+        rentalsComponent.getRentalsListings({
+          offset: 0,
+          limit: 10,
+          sortBy: null,
+          sortDirection: null,
+          filterBy: {},
+        }, true)
+      ).resolves.toEqual(dbGetRentalListings)
+
+      expect(dbQueryMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          strings: expect.arrayContaining([expect.not.stringContaining("DISTINCT ON (rentals.metadata_id)")]),
+          values: [10, 0],
+        })
+      )
+    })
+  })
+
+  describe("and getHistoricData flag is off", () => {
+    beforeEach(() => {
+      dbGetRentalListings = []
+      dbQueryMock.mockResolvedValueOnce({ rows: dbGetRentalListings })
+    })
+
+    it("should only retrieve one rental for each nft (metadata_id)", async () => {
+      await expect(
+        rentalsComponent.getRentalsListings({
+          offset: 0,
+          limit: 10,
+          sortBy: null,
+          sortDirection: null,
+          filterBy: {},
+        }, false)
+      ).resolves.toEqual(dbGetRentalListings)
+
+      expect(dbQueryMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          strings: expect.arrayContaining([expect.stringContaining("DISTINCT ON (rentals.metadata_id)")]),
+          values: [10, 0],
+        })
+      )
+    })
+  })
 })
 
 describe("when refreshing rental listings", () => {


### PR DESCRIPTION
set correct distinct on if the historic data is not required