### PR TITLE
feat: add rental days filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "template-server",
       "dependencies": {
-        "@dcl/schemas": "^6.11.1",
+        "@dcl/schemas": "/Users/melisaanabellarossi/development/common-schemas/dcl-schemas-0.0.3.tgz",
         "@well-known-components/env-config-provider": "^1.2.0",
         "@well-known-components/http-server": "^1.1.6",
         "@well-known-components/http-tracer-component": "^1.0.3",
@@ -664,9 +664,10 @@
       }
     },
     "node_modules/@dcl/schemas": {
-      "version": "6.11.1",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-6.11.1.tgz",
-      "integrity": "sha512-KwXZEB9sraL9sypHqh2iquTRIERyPoKBdp31DF+BCS775p+mNEJQUw4iXF8X0XH6S5vnOi8WzZUr2Nk6AE8pCg==",
+      "version": "0.0.0",
+      "resolved": "file:../common-schemas/dcl-schemas-0.0.3.tgz",
+      "integrity": "sha512-tIA7ciN+zsGY+0ovfmWAdq71uIf2wfrtnZwuFEfktTw6bO/IJ51jDttVPhaTAbmVQGzjWYZuuT0rzqR04GqZdw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",
@@ -9658,9 +9659,8 @@
       }
     },
     "@dcl/schemas": {
-      "version": "6.11.1",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-6.11.1.tgz",
-      "integrity": "sha512-KwXZEB9sraL9sypHqh2iquTRIERyPoKBdp31DF+BCS775p+mNEJQUw4iXF8X0XH6S5vnOi8WzZUr2Nk6AE8pCg==",
+      "version": "file:/Users/melisaanabellarossi/development/common-schemas/dcl-schemas-0.0.3.tgz",
+      "integrity": "sha512-tIA7ciN+zsGY+0ovfmWAdq71uIf2wfrtnZwuFEfktTw6bO/IJ51jDttVPhaTAbmVQGzjWYZuuT0rzqR04GqZdw==",
       "requires": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "template-server",
       "dependencies": {
-        "@dcl/schemas": "/Users/melisaanabellarossi/development/common-schemas/dcl-schemas-0.0.3.tgz",
+        "@dcl/schemas": "^6.12.0",
         "@well-known-components/env-config-provider": "^1.2.0",
         "@well-known-components/http-server": "^1.1.6",
         "@well-known-components/http-tracer-component": "^1.0.3",
@@ -664,10 +664,9 @@
       }
     },
     "node_modules/@dcl/schemas": {
-      "version": "0.0.0",
-      "resolved": "file:../common-schemas/dcl-schemas-0.0.3.tgz",
-      "integrity": "sha512-tIA7ciN+zsGY+0ovfmWAdq71uIf2wfrtnZwuFEfktTw6bO/IJ51jDttVPhaTAbmVQGzjWYZuuT0rzqR04GqZdw==",
-      "license": "Apache-2.0",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-6.12.0.tgz",
+      "integrity": "sha512-/iprDm4H5JBvAJK132SAGUM31zAFkKnEvYhUFBhb2MV6WWFwPAKoOpg1nO6yxDtSSmL0LnwkmmsFBrBQwwXp/g==",
       "dependencies": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",
@@ -9659,8 +9658,9 @@
       }
     },
     "@dcl/schemas": {
-      "version": "file:/Users/melisaanabellarossi/development/common-schemas/dcl-schemas-0.0.3.tgz",
-      "integrity": "sha512-tIA7ciN+zsGY+0ovfmWAdq71uIf2wfrtnZwuFEfktTw6bO/IJ51jDttVPhaTAbmVQGzjWYZuuT0rzqR04GqZdw==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-6.12.0.tgz",
+      "integrity": "sha512-/iprDm4H5JBvAJK132SAGUM31zAFkKnEvYhUFBhb2MV6WWFwPAKoOpg1nO6yxDtSSmL0LnwkmmsFBrBQwwXp/g==",
       "requires": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "semi": false
   },
   "dependencies": {
-    "@dcl/schemas": "^6.11.1",
+    "@dcl/schemas": "/Users/melisaanabellarossi/development/common-schemas/dcl-schemas-0.0.3.tgz",
     "@well-known-components/env-config-provider": "^1.2.0",
     "@well-known-components/http-server": "^1.1.6",
     "@well-known-components/http-tracer-component": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "semi": false
   },
   "dependencies": {
-    "@dcl/schemas": "/Users/melisaanabellarossi/development/common-schemas/dcl-schemas-0.0.3.tgz",
+    "@dcl/schemas": "^6.12.0",
     "@well-known-components/env-config-provider": "^1.2.0",
     "@well-known-components/http-server": "^1.1.6",
     "@well-known-components/http-tracer-component": "^1.0.3",

--- a/src/controllers/handlers/rentals-handlers.ts
+++ b/src/controllers/handlers/rentals-handlers.ts
@@ -68,7 +68,8 @@ export async function getRentalsListingsHandler(
       maxDistanceToPlaza: getNumberParameter("maxDistanceToPlaza", url.searchParams.get("maxDistanceToPlaza")),
       minEstateSize: getNumberParameter("minEstateSize", url.searchParams.get("minEstateSize")),
       maxEstateSize: getNumberParameter("maxEstateSize", url.searchParams.get("maxEstateSize")),
-      adjacentToRoad: getBooleanParameter("adjacentToRoad", url.searchParams.get("adjacentToRoad"))
+      adjacentToRoad: getBooleanParameter("adjacentToRoad", url.searchParams.get("adjacentToRoad")),
+      rentalDays: url.searchParams.getAll("rentalDays").map((value) => getNumberParameter("rentalDays", value)).filter(Boolean) as number[]
     }
     const rentalListings = await rentals.getRentalsListings(
       {

--- a/src/ports/rentals/component.ts
+++ b/src/ports/rentals/component.ts
@@ -1,4 +1,4 @@
-import SQL, { SQLStatement } from "sql-template-strings"
+import SQL from "sql-template-strings"
 import {
   ChainName,
   getChainId,
@@ -48,7 +48,7 @@ import {
 } from "./types"
 import { buildQueryParameters } from "./graph"
 import { generateECDSASignatureWithInvalidV, generateECDSASignatureWithValidV, hasECDSASignatureAValidV } from "./utils"
-import { getRentalListingsQuery } from "./queries"
+import { getRentalListingsQuery } from "./queries/getRentalsListings"
 
 export async function createRentalsComponent(
   components: Pick<AppComponents, "database" | "logs" | "marketplaceSubgraph" | "rentalsSubgraph" | "config">

--- a/src/ports/rentals/component.ts
+++ b/src/ports/rentals/component.ts
@@ -48,7 +48,7 @@ import {
 } from "./types"
 import { buildQueryParameters } from "./graph"
 import { generateECDSASignatureWithInvalidV, generateECDSASignatureWithValidV, hasECDSASignatureAValidV } from "./utils"
-import { getRentalListingsQuery } from "./queries/getRentalsListings"
+import { getRentalListingsQuery } from "./queries"
 
 export async function createRentalsComponent(
   components: Pick<AppComponents, "database" | "logs" | "marketplaceSubgraph" | "rentalsSubgraph" | "config">

--- a/src/ports/rentals/queries/index.ts
+++ b/src/ports/rentals/queries/index.ts
@@ -1,0 +1,1 @@
+export * from './getRentalsListings'

--- a/test/unit/rentals-component.spec.ts
+++ b/test/unit/rentals-component.spec.ts
@@ -1276,6 +1276,35 @@ describe("when getting rental listings", () => {
       )
     })
   })
+
+  describe("and the rentalDays filter is set", () => {
+    beforeEach(() => {
+      dbGetRentalListings = []
+      dbQueryMock.mockResolvedValueOnce({ rows: dbGetRentalListings })
+    })
+  
+    it("should join rental days select", async () => {
+      await expect(
+        rentalsComponent.getRentalsListings({
+          offset: 0,
+          limit: 10,
+          sortBy: null,
+          sortDirection: null,
+          filterBy: { rentalDays: [1, 7] },
+        }, false)
+      ).resolves.toEqual(dbGetRentalListings)
+
+      expect(dbQueryMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          strings: expect.arrayContaining([
+            expect.stringContaining("SELECT DISTINCT rental_id FROM periods WHERE (min_days <= "),
+            expect.stringContaining("AND max_days >= "),
+          ]),
+          values: [1, 1, 7, 7, 10, 0],
+        })
+      )
+    })
+  })
 })
 
 describe("when refreshing rental listings", () => {


### PR DESCRIPTION
Add possibility to filter by rental days.

Technical decisions: To be able to filter the nfts that have periods that match the ones passed by query param without filtering the periods returned in the result of the query we had to add a new SELECT to the rentals query that join all periods that match from the periods table. 

- If we filter by days 30 in the where clause without adding the join

```
SELECT *...
WHERE periods.min_days <= 30 and periods.max_days >= 30
...
```
Result
```
{
   id: 1,
   "periods": [
          {
              "minDays": 30,
              "maxDays": 30,
              "pricePerDay": "20000000000000000000"
          }
      ]
}
```
- If we filter by days 30 in the where clause with join
```
SELECT *...
FROM rentals, periods, (SELECT rentals_id FROM periods WHERE min_days <= 30 and max_days >= 30) as rental_days_periods
WHERE rentals.id = rental_days_periods.rental_id
```

Result
```
{
   id: 1,
   "periods": [
          {
              "minDays": 1,
              "maxDays": 1,
              "pricePerDay": "20000000000000000000"
          },
          {
              "minDays": 30,
              "maxDays": 30,
              "pricePerDay": "20000000000000000000"
          }
      ]
}
```
