### PR TITLE
fix: Update crypto middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@well-known-components/tracer-component": "^1.1.1",
         "ajv": "^8.12.0",
         "ajv-formats": "^2.1.1",
-        "decentraland-crypto-middleware": "^1.0.4",
+        "decentraland-crypto-middleware": "^1.1.0",
         "decentraland-transactions": "^1.42.0",
         "ethers": "^5.7.2",
         "p-limit": "^3.1.0",
@@ -3275,9 +3275,9 @@
       }
     },
     "node_modules/decentraland-crypto-middleware": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/decentraland-crypto-middleware/-/decentraland-crypto-middleware-1.0.4.tgz",
-      "integrity": "sha512-TGZ0lYR8LxI+swWX3vVxhIGhKcDXlYR/cRiIFgjpca9xwmTSd0uvbJ2ZAkR801rMm+xn8F/j+0t5Tn7jCLXylA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/decentraland-crypto-middleware/-/decentraland-crypto-middleware-1.1.0.tgz",
+      "integrity": "sha512-P55VRIQ1GHxRlJPPW6B+MGKzaT1PNdi/yrZrtmjKPSmaswXYtw9FOACK7uxmQEF2E6AstLVRXJ0DgI3FkQsnbQ==",
       "dependencies": {
         "dcl-crypto": "^2.3.0",
         "isomorphic-fetch": "^3.0.0",
@@ -11625,9 +11625,9 @@
       "integrity": "sha512-VfxadyCECXgQlkoEAjeghAr5gY3Hf+IKjKb+X8tGVDtveCjN+USwprd2q3QXBR9T1+x2DG0XZF5/w+7HAtSaXA=="
     },
     "decentraland-crypto-middleware": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/decentraland-crypto-middleware/-/decentraland-crypto-middleware-1.0.4.tgz",
-      "integrity": "sha512-TGZ0lYR8LxI+swWX3vVxhIGhKcDXlYR/cRiIFgjpca9xwmTSd0uvbJ2ZAkR801rMm+xn8F/j+0t5Tn7jCLXylA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/decentraland-crypto-middleware/-/decentraland-crypto-middleware-1.1.0.tgz",
+      "integrity": "sha512-P55VRIQ1GHxRlJPPW6B+MGKzaT1PNdi/yrZrtmjKPSmaswXYtw9FOACK7uxmQEF2E6AstLVRXJ0DgI3FkQsnbQ==",
       "requires": {
         "dcl-crypto": "^2.3.0",
         "isomorphic-fetch": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@well-known-components/tracer-component": "^1.1.1",
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",
-    "decentraland-crypto-middleware": "^1.0.4",
+    "decentraland-crypto-middleware": "^1.1.0",
     "decentraland-transactions": "^1.42.0",
     "ethers": "^5.7.2",
     "p-limit": "^3.1.0",


### PR DESCRIPTION
This PR updates the crypto middleware so any "Expired signature" errors are more verbose, including all the timestamps in the signature expiration procedure.