### PR TITLE
feat: bump @dcl/crypto-middleware to 4.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "template-server",
       "dependencies": {
         "@dcl/core-commons": "^0.10.1",
-        "@dcl/crypto-middleware": "^4.0.0",
+        "@dcl/crypto-middleware": "^4.1.0",
         "@dcl/fetch-component": "^1.1.0",
         "@dcl/http-requests-logger-component": "^1.0.0",
         "@dcl/http-server": "^2.0.2",
@@ -768,9 +768,9 @@
       }
     },
     "node_modules/@dcl/crypto-middleware": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@dcl/crypto-middleware/-/crypto-middleware-4.0.0.tgz",
-      "integrity": "sha512-j12R22lMBYk5zwXRzoKxGvU+F8IER+iV9buehbriHPkxVQdBOBqS0EoWtREpanGW1MLhHqoAijsOft1hXzc/rA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@dcl/crypto-middleware/-/crypto-middleware-4.1.0.tgz",
+      "integrity": "sha512-F9MVyxnLFaLJSyo5o6MtsGTDiQ1r4VqCKuFkaEPcq2JFyI6W4ftIRaKIj7hLb65PP/ywm3FkQrizSJ+6MhWpZw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/core-commons": "^0.10.0",
@@ -7154,9 +7154,9 @@
       }
     },
     "@dcl/crypto-middleware": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@dcl/crypto-middleware/-/crypto-middleware-4.0.0.tgz",
-      "integrity": "sha512-j12R22lMBYk5zwXRzoKxGvU+F8IER+iV9buehbriHPkxVQdBOBqS0EoWtREpanGW1MLhHqoAijsOft1hXzc/rA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@dcl/crypto-middleware/-/crypto-middleware-4.1.0.tgz",
+      "integrity": "sha512-F9MVyxnLFaLJSyo5o6MtsGTDiQ1r4VqCKuFkaEPcq2JFyI6W4ftIRaKIj7hLb65PP/ywm3FkQrizSJ+6MhWpZw==",
       "requires": {
         "@dcl/core-commons": "^0.10.0",
         "@dcl/crypto": "3.7.0"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@dcl/core-commons": "^0.10.1",
-    "@dcl/crypto-middleware": "^4.0.0",
+    "@dcl/crypto-middleware": "^4.1.0",
     "@dcl/fetch-component": "^1.1.0",
     "@dcl/http-requests-logger-component": "^1.0.0",
     "@dcl/http-server": "^2.0.2",


### PR DESCRIPTION
## what

bump `@dcl/crypto-middleware` from `^4.0.0` to `^4.1.0` to pick up the latest published release (4.1.0).

## notes

follow-up to the recently merged `@well-known-components` → `@dcl` migration; `@dcl/crypto-middleware@4.1.0` was published after those PRs merged, so the dependency is updated here on its own.

## verification

- install refreshes the lockfile to `@dcl/crypto-middleware@4.1.0`.
- the typescript build passes.
