### PR TITLE
fix: Normalize the scene signer and bump @dcl/crypto-middleware to 5.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@dcl/core-commons": "^0.10.1",
-    "@dcl/crypto-middleware": "^4.1.1",
+    "@dcl/crypto-middleware": "5.1.0",
     "@dcl/fetch-component": "^1.1.1",
     "@dcl/http-requests-logger-component": "^1.0.0",
     "@dcl/http-server": "^2.1.0",

--- a/src/middlewares/withSignerValidation.ts
+++ b/src/middlewares/withSignerValidation.ts
@@ -4,11 +4,12 @@ export async function withSignerValidation(
   ctx: IHttpServerComponent.DefaultContext<any>,
   next: () => Promise<IHttpServerComponent.IResponse>
 ): Promise<IHttpServerComponent.IResponse> {
-  if (
-    ctx.verification?.authMetadata &&
-    typeof ctx.verification.authMetadata === 'object' &&
-    ctx.verification.authMetadata.signer === 'decentraland-kernel-scene'
-  ) {
+  // Normalized rather than compared exactly: the signed payload is lowercased, so casing is not
+  // covered by the signature and a scene can deliver any spelling with a still-valid signature.
+  // @dcl/crypto-middleware v5 rejects non-canonical metadata upstream, but this must not depend on
+  // that guard staying in place.
+  const signer = ctx.verification?.authMetadata?.signer
+  if (typeof signer === 'string' && signer.trim().toLowerCase() === 'decentraland-kernel-scene') {
     return {
       status: 400,
       body: 'Invalid signer',

--- a/test/integration/rentals-listings-creation-controller.spec.ts
+++ b/test/integration/rentals-listings-creation-controller.spec.ts
@@ -1,5 +1,6 @@
 import { ChainId, NFTCategory, RentalListingCreation, RentalStatus } from "@dcl/schemas"
-import { getIdentity, Identity } from "@dcl/test-helpers"
+import { AUTH_METADATA_HEADER } from "@dcl/crypto-middleware"
+import { getIdentity, getSignedAuthHeaders, Identity } from "@dcl/test-helpers"
 import { ethers } from "ethers"
 import { getRentalsContract } from "../../src/logic/rentals"
 import { StatusCode } from "../../src/types"
@@ -69,6 +70,37 @@ test("when creating a rental listing through the API", function ({ components, s
     it("should respond with a 400 rejecting the signer", async () => {
       expect(response.status).toBe(StatusCode.BAD_REQUEST)
       await expect(response.text()).resolves.toBe("Invalid signer")
+    })
+  })
+
+  describe("and the scene signer is signed but a mixed-case spelling is delivered", () => {
+    let response: Response
+
+    beforeEach(async () => {
+      const headers = getSignedAuthHeaders("POST", PATH, { signer: "decentraland-kernel-scene" }, identity)
+      // The signed payload is lowercased, so re-casing the delivered metadata keeps the signature
+      // genuinely valid while reading differently to withSignerValidation's strict comparison. This
+      // is the attack: without the guard the scene request passes as a directly user-signed one.
+      headers[AUTH_METADATA_HEADER] = JSON.stringify({ signer: "Decentraland-Kernel-Scene" })
+
+      response = await components.localFetch.fetch(PATH, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify(listing),
+      })
+    })
+
+    it("should respond with a 400 rejecting the metadata before the signer check runs", async () => {
+      expect(response.status).toBe(StatusCode.BAD_REQUEST)
+      // The raw metadata is echoed back truncated at 64 characters, so match the prefix.
+      await expect(response.json()).resolves.toEqual({
+        ok: false,
+        message: expect.stringMatching(/^Invalid chain metadata: /),
+      })
+    })
+
+    it("should not reach the rentals component", () => {
+      expect(stubComponents.rentalsSubgraph.query).not.toHaveBeenCalled()
     })
   })
 

--- a/test/unit/withSignerValidation-middleware.spec.ts
+++ b/test/unit/withSignerValidation-middleware.spec.ts
@@ -26,6 +26,72 @@ describe("withSignerValidation", () => {
     })
   })
 
+  describe("when signer is decentraland-kernel-scene in a non-canonical casing", () => {
+    beforeEach(() => {
+      ctx = {
+        verification: {
+          authMetadata: {
+            signer: "Decentraland-Kernel-Scene",
+          },
+        },
+      }
+    })
+
+    // The signed payload is lowercased, so casing is not covered by the signature. The middleware
+    // has to normalize instead of relying on @dcl/crypto-middleware rejecting it upstream.
+    it('should return 400 status and "Invalid signer" body', async () => {
+      const next = jest.fn()
+      const result = await withSignerValidation(ctx, next)
+      expect(result).toEqual({
+        status: 400,
+        body: "Invalid signer",
+      })
+      expect(next).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("when signer is decentraland-kernel-scene padded with whitespace", () => {
+    beforeEach(() => {
+      ctx = {
+        verification: {
+          authMetadata: {
+            signer: " decentraland-kernel-scene ",
+          },
+        },
+      }
+    })
+
+    it('should return 400 status and "Invalid signer" body', async () => {
+      const next = jest.fn()
+      const result = await withSignerValidation(ctx, next)
+      expect(result).toEqual({
+        status: 400,
+        body: "Invalid signer",
+      })
+      expect(next).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("when signer is not a string", () => {
+    beforeEach(() => {
+      ctx = {
+        verification: {
+          authMetadata: { signer: 123 },
+        },
+      }
+    })
+
+    // Metadata is attacker supplied and only checked to be an object, so normalizing has to be
+    // guarded by a type check or the middleware throws instead of answering the request.
+    it("should call next() and return its result", async () => {
+      const nextResult = { status: 200, body: "Success" }
+      const next = jest.fn().mockResolvedValue(nextResult)
+      const result = await withSignerValidation(ctx, next)
+      expect(result).toEqual(nextResult)
+      expect(next).toHaveBeenCalled()
+    })
+  })
+
   describe("when signer is not defined", () => {
     beforeEach(() => {
       ctx = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -311,7 +311,15 @@
   dependencies:
     "@well-known-components/interfaces" "^1.5.2"
 
-"@dcl/crypto-middleware@^4.0.0", "@dcl/crypto-middleware@^4.1.1":
+"@dcl/crypto-middleware@5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@dcl/crypto-middleware/-/crypto-middleware-5.1.0.tgz#382bc899d4f9cb07541baa7d35a4322e5810ea77"
+  integrity sha512-aiG/aInYDgL5Er+KStaIqjOmGGLlmIHSRlcAK5Jzyn+wiPU/kYiQIpMDyaIsrZ0om9HOi0M6lnqcR7ZVNpj4bA==
+  dependencies:
+    "@dcl/core-commons" "^0.10.0"
+    "@dcl/crypto" "3.7.0"
+
+"@dcl/crypto-middleware@^4.0.0":
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/@dcl/crypto-middleware/-/crypto-middleware-4.1.1.tgz#a46861caa68bf38f0355ce72d77a8232200d54ed"
   integrity sha512-wNo3D00SyZKoxy3THQj+EMWWatU9F2VTPwqTIVWZj3JlnaKRScNpLOsrHVPETN9FYtTIlJqqhjlUWsjoUGVisw==


### PR DESCRIPTION
## Description

Bumps `@dcl/crypto-middleware` from `^4.1.1` to `5.1.0` and adds an integration test covering the
vulnerability that version closes.

The signed-fetch payload (`method:path:timestamp:metadata`) is **lowercased before signing**, so
casing is not covered by the signature. `src/middlewares/withSignerValidation.ts:10` rejects scene
requests with an exact, case-sensitive `=== 'decentraland-kernel-scene'` comparison. A scene could
therefore sign normally but deliver `x-identity-metadata` as `{"signer":"Decentraland-Kernel-Scene"}`
— the signature still verifies, the strict comparison misses it, and the request passes as a
directly user-signed one.

v5's `verifyMetadata` rejects non-canonical `signer`/`intent` values (must be trimmed and lowercase;
hex addresses are exempt so EIP-55 checksum casing still works) with a 400 before the signer check
ever runs.

The major version bump is otherwise inert here: it removed the `express()` and `koa()` adapter
exports, which this service does not use. `wellKnownComponents` is **byte-identical** between 4.1.1
and 5.1.0.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Infrastructure / CI/CD
- [ ] Performance improvement

## Changes Made

- `package.json` / `yarn.lock` — pin `@dcl/crypto-middleware` to `5.1.0` (from `^4.1.1`).
- `test/integration/rentals-listings-creation-controller.spec.ts` — add a case that signs as
  `decentraland-kernel-scene`, then re-cases only the delivered metadata header so the signature
  stays genuinely valid, and asserts a 400 `Invalid chain metadata` plus that the rentals component
  is never reached.
- `src/middlewares/withSignerValidation.ts` — normalize the signer (trim + lowercase) before
  comparing, so the scene restriction no longer depends on the library's metadata guard. Added in
  response to review; see "Review follow-ups" below.
- `test/unit/withSignerValidation-middleware.spec.ts` — three cases covering the normalization:
  mixed casing, whitespace padding, and a non-string signer.

## Why `5.1.0` is pinned without a caret

Intentional, and it differs from the caret ranges other `@dcl/*` deps in `package.json` use. This
dependency is the service's only authentication boundary, and the 4→5 major bump *was itself* a
security fix that changed request-rejection behavior. An exact pin means a resolution change to this
package can only happen as a reviewed commit, never as a side effect of an unrelated `yarn install`.

This note lives in the PR rather than beside the dependency because `package.json` is strict JSON
and cannot carry comments.

## How to Test

1. `docker compose up -d` then `yarn test` (integration tests need the postgres from
   `docker-compose.yml`; connection comes from `.env.test`).
2. Confirm `test/integration/rentals-listings-creation-controller.spec.ts` passes all 17 tests. Two
   of them matter together: the new mixed-case case must 400 with `Invalid chain metadata`, and the
   existing lowercase scene case must still 400 with `Invalid signer`. That proves the library guard
   and `withSignerValidation` each fire on their own path rather than one masking the other.
3. Verify no caller regression: v5 only rejects `signer`/`intent` that are not trimmed-lowercase.
   Production callers of `POST /v1/rentals-listings` send lowercase values only, and other metadata
   fields (`origin`, `sceneId`, …) plus checksummed hex addresses are unaffected.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-reviewed the code for obvious errors
- [x] Added or updated tests where applicable
- [ ] Existing tests pass locally — see note below
- [ ] Updated documentation if needed
- [x] No new warnings or console errors introduced

## Review follow-ups

All three P2 suggestions addressed:

1. **Defense in depth in `withSignerValidation`** — done in `476102d`. Implemented as
   `typeof signer === 'string' && signer.trim().toLowerCase() === 'decentraland-kernel-scene'`
   rather than the suggested `signer?.toLowerCase()`: `?.` only guards `null`/`undefined`, so a
   payload of `{"signer": 123}` would reach `(123).toLowerCase()` and throw. Metadata is attacker
   supplied and only validated to be an object, so that was a reachable 500 on a public endpoint —
   there is now a unit test for it. `.trim()` was added too, matching the canonical form the library
   enforces. Pulling the value out with optional chaining also made the previous
   `typeof authMetadata === 'object'` guard redundant, so the check is shorter than before.
2. **Exact pin rationale** — documented above under "Why `5.1.0` is pinned without a caret".
   `package.json` is strict JSON, so an inline comment is not possible.
3. **Title type** — retitled from `chore:` to `fix:`.

**Note on the test suite:** `yarn test` is `2 failed, 300 passed, 302 total`. Both failures are in
`test/integration/rentals-jobs.spec.ts` (`should advance the updated at of the expired listing`,
`should cancel the expired listing`) and are **pre-existing on `main`**, not caused by this change.
Verified by checking out `main` in a separate worktree and installing `crypto-middleware@4.1.1`:
that baseline gives the identical two failures (`2 failed, 295 passed, 297 total` — the +5 here are
the new auth tests, all passing). This branch does not touch that spec, and the only `src/` file it
changes is `withSignerValidation.ts`, which the jobs never call.

Lead for whoever picks that up: the expiry sweep at `src/ports/rentals/component.ts:891` runs inside
the job transaction, and the `catch` at `:896` does a silent `ROLLBACK` that discards the error. Both
tests stub with `mockResolvedValueOnce`, so if the job issues more than one subgraph query the mock
is exhausted, the job throws, and the rollback leaves the listing `open` with `updated_at` untouched
— matching both symptoms.

## Related Issues

<!-- Link related tickets or issues. Use "Closes #123" to auto-close. -->

## Screenshots

<!-- If applicable, add screenshots or screen recordings. -->
